### PR TITLE
Update log file name for Windows on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ To install the compiled version, choose the one for your **OS** and simply **dou
 
 By default, Leapp writes logs to the following locations:
 
-- on Linux: ~/.config/{app name}/logs/{process type}.log
-- on macOS: ~/Library/Logs/{app name}/{process type}.log
-- on Windows: %USERPROFILE%\AppData\Roaming\{app name}\logs\{process type}.log
+- on Linux: `~/.config/{app name}/logs/{process type}.log`
+- on macOS: `~/Library/Logs/{app name}/{process type}.log`
+- on Windows: `%USERPROFILE%\AppData\Roaming\Leapp\log.log`
 
 # Tutorials
 


### PR DESCRIPTION
**Changelog**

Minor change to the readme: I wrote the exact path of the log file which I found on my Windows 10 pc.

**Notes**

Hopefully the path is the same on all Windows systems.
I removed the `App Name` placeholder, as I think that it should always be `Leapp`. I wonder if it could be something different on MacOS/Linux.
Also, I don't know if the `{process type}` placeholder is relevant.