### PR TITLE
feat: add placeholder example of AWS SSO Url

### DIFF
--- a/src/app/components/aws-sso/aws-sso.component.html
+++ b/src/app/components/aws-sso/aws-sso.component.html
@@ -16,7 +16,7 @@
         <div class="form-group" style="width: 100%; display: inline-block;">
           <label><strong>Aws Single Sign-On Url</strong><span class="danger-text">*</span></label>
           <br>
-          <input formControlName="portalUrl" type="url" class="form-control" placeholder="aws SSO url *">
+          <input formControlName="portalUrl" type="url" class="form-control" placeholder="aws SSO url (eg https://d-xxxxxxxxxx.awsapps.com/start) *">
           <small class="text-error" *ngIf="(form.controls['portalUrl'].dirty || form.controls['portalUrl'].touched) && form.controls['portalUrl'].errors">Insert the Aws Single Sign-On url</small>
         </div>
 


### PR DESCRIPTION
**Changelog**

* Added placeholder example for AWS SSO Url in input field

**Enhancements**

Minor change to help make it clearer what the AWS SSO Url format should be.