### PR TITLE
feat: add tooltip to show session & detail info

### DIFF
--- a/src/app/components/session/session-card/detail.pipe.ts
+++ b/src/app/components/session/session-card/detail.pipe.ts
@@ -14,15 +14,15 @@ export class DetailPipe implements PipeTransform {
   transform(session: Session): string {
     switch (session.type) {
       case(SessionType.awsIamRoleFederated):
-        return ' - ' + (session as AwsIamRoleFederatedSession).roleArn.split('role/')[1];
+        return (session as AwsIamRoleFederatedSession).roleArn.split('role/')[1];
       case(SessionType.azure):
-        return ' - ' + (session as AzureSession).subscriptionId;
+        return (session as AzureSession).subscriptionId;
       case(SessionType.awsIamUser):
         return ''; // (session as AwsIamUserSession).sessionName;
       case(SessionType.awsSsoRole):
-        return ' - ' + (session as AwsSsoRoleSession).roleArn.split('role/')[1];
+        return (session as AwsSsoRoleSession).roleArn.split('role/')[1];
       case(SessionType.awsIamRoleChained):
-        return ' - ' + (session as AwsIamRoleChainedSession).roleArn.split('role/')[1];
+        return (session as AwsIamRoleChainedSession).roleArn.split('role/')[1];
     }
   }
 }

--- a/src/app/components/session/session-card/session-card.component.html
+++ b/src/app/components/session/session-card/session-card.component.html
@@ -1,7 +1,7 @@
 <div class="session-card button-area  {{session.type === eSessionType.azure ? 'azr' : 'aws'}} {{session.status === eSessionStatus.active ? 'active' : ''}}">
   <span class="region-label {{session.type === eSessionType.azure ? 'azr' : 'aws'}}">{{session.region}}</span>
   <div class="information" (click)="switchCredentials()" title="{{ session | detail }}">
-    <b>{{session.sessionName}}</b>{{ session | detail }}
+    <b>{{session.sessionName}}</b> - {{ session | detail }}
   </div>
   <div class="information-profile" (click)="switchCredentials()">
     <ng-container *ngIf="session.type !== eSessionType.azure">

--- a/src/app/components/session/session-card/session-card.component.html
+++ b/src/app/components/session/session-card/session-card.component.html
@@ -1,6 +1,6 @@
 <div class="session-card button-area  {{session.type === eSessionType.azure ? 'azr' : 'aws'}} {{session.status === eSessionStatus.active ? 'active' : ''}}">
   <span class="region-label {{session.type === eSessionType.azure ? 'azr' : 'aws'}}">{{session.region}}</span>
-  <div class="information" (click)="switchCredentials()">
+  <div class="information" (click)="switchCredentials()" title="{{ session | detail }}">
     <b>{{session.sessionName}}</b>{{ session | detail }}
   </div>
   <div class="information-profile" (click)="switchCredentials()">


### PR DESCRIPTION
**Changelog**

After resolving #166 the session & detail info can be too long to display. This adds a tooltip to make the full string visible.

**Enhancements**

Before:
![image](https://user-images.githubusercontent.com/6945933/132533425-29752c7a-d373-40df-935a-caaf9a8f3ac5.png)

After:
![image](https://user-images.githubusercontent.com/6945933/132533449-831caf86-a8ad-45b3-bace-b5eb21ce9ead.png)


