### PR TITLE
feat: add the option to select between Terminal and iTerm2 under MacOS [LEAP-288]

### DIFF
--- a/src/app/components/shared/profile-page/profile-page.component.html
+++ b/src/app/components/shared/profile-page/profile-page.component.html
@@ -33,6 +33,12 @@
           </div>
           -->
 
+          <h2 style="margin-top: 10px;">External programs</h2>
+          <div class="form-group" style="width: 43%; display: inline-block;">
+            <label>MacOS terminal</label>
+            <ng-select formControlName="macOsTerminalsSelect" bindLabel="terminal" bindValue="terminal" [items]="[{terminal: eConstants.macOsTerminal.toString() }, {terminal: eConstants.macOsiTerm2.toString() }]" [(ngModel)]="selectedMacOsTerminal" dropdownPosition="down"></ng-select>
+          </div>
+
         </div>
       </mat-tab>
       <mat-tab>

--- a/src/app/components/shared/profile-page/profile-page.component.ts
+++ b/src/app/components/shared/profile-page/profile-page.component.ts
@@ -45,6 +45,7 @@ export class ProfilePageComponent implements OnInit {
   selectedLocation: string;
   selectedRegion: string;
   selectedBrowserOpening = Constants.inApp.toString();
+  selectedMacOsTerminal: string;
 
   public form = new FormGroup({
     idpUrl: new FormControl(''),
@@ -57,7 +58,8 @@ export class ProfilePageComponent implements OnInit {
     showAuthCheckbox: new FormControl(''),
     regionsSelect: new FormControl(''),
     locationsSelect: new FormControl(''),
-    defaultBrowserOpening: new FormControl('')
+    defaultBrowserOpening: new FormControl(''),
+    macOsTerminalsSelect: new FormControl('')
   });
 
   /* Simple profile page: shows the Idp Url and the workspace json */
@@ -101,6 +103,7 @@ export class ProfilePageComponent implements OnInit {
     this.locations = this.appService.getLocations();
     this.selectedRegion   = this.workspace.defaultRegion || environment.defaultRegion;
     this.selectedLocation = this.workspace.defaultLocation || environment.defaultLocation;
+    this.selectedMacOsTerminal = this.workspace.macOsTerminal || Constants.macOsTerminal.toString();
 
     this.appService.validateAllFormFields(this.form);
   }
@@ -125,6 +128,9 @@ export class ProfilePageComponent implements OnInit {
 
       // this.workspace.awsSsoConfiguration.browserOpening = this.selectedBrowserOpening;
       // this.workspaceService.updateBrowserOpening(this.selectedBrowserOpening);
+
+      this.workspace.macOsTerminal = this.selectedMacOsTerminal;
+      this.workspaceService.updateMacOsTerminal(this.workspace.macOsTerminal);
 
       if (this.checkIfNeedDialogBox()) {
 

--- a/src/app/models/constants.ts
+++ b/src/app/models/constants.ts
@@ -8,5 +8,7 @@ export enum Constants {
   windows = 'windows',
   inApp = 'In-app',
   inBrowser = 'In-browser',
+  macOsTerminal = 'Terminal',
+  macOsiTerm2 = 'iTerm2',
   forcedCloseBrowserWindow = 'ForceCloseBrowserWindow',
 }

--- a/src/app/models/workspace.ts
+++ b/src/app/models/workspace.ts
@@ -43,7 +43,7 @@ export class Workspace {
       username: undefined,
       password: undefined
     };
-    this._macOsTerminal = environment.macOsTerminal;
+    this._macOsTerminal = Constants.macOsTerminal;
   }
 
   get sessions(): Session[] {

--- a/src/app/models/workspace.ts
+++ b/src/app/models/workspace.ts
@@ -11,6 +11,7 @@ export class Workspace {
   private _defaultLocation: string;
   private _idpUrls: { id: string; url: string }[];
   private _profiles: { id: string; name: string }[];
+  private _macOsTerminal: string;
 
   private _awsSsoIntegrations: AwsSsoIntegration[];
 
@@ -42,6 +43,7 @@ export class Workspace {
       username: undefined,
       password: undefined
     };
+    this._macOsTerminal = environment.macOsTerminal;
   }
 
   get sessions(): Session[] {
@@ -102,5 +104,13 @@ export class Workspace {
 
   get version(): string {
     return this._version;
+  }
+
+  get macOsTerminal(): string {
+    return this._macOsTerminal;
+  }
+
+  set macOsTerminal(value: string) {
+    this._macOsTerminal = value;
   }
 }

--- a/src/app/models/workspace.ts
+++ b/src/app/models/workspace.ts
@@ -2,6 +2,7 @@ import {Session} from './session';
 import * as uuid from 'uuid';
 import {environment} from '../../environments/environment';
 import {Type} from 'class-transformer';
+import {Constants} from './constants';
 import {AwsSsoIntegration} from './aws-sso-integration';
 
 export class Workspace {

--- a/src/app/services/app.service.ts
+++ b/src/app/services/app.service.ts
@@ -494,6 +494,18 @@ export class AppService {
     ];
   }
 
+   /**
+   * Get supported MacOs terminals
+   *
+   * @returns - [{terminal: string}] - all supported MacOs terminals in array format
+   */
+    getMacOsTerminals() {
+      return [
+        {terminal: 'Terminal'},
+        {terminal: 'iTerm2'}
+      ];
+    }
+
   /**
    * To use EC2 services with the client you need to change the
    * request header because the origin for electron app is of type file

--- a/src/app/services/workspace.service.ts
+++ b/src/app/services/workspace.service.ts
@@ -243,4 +243,15 @@ export class WorkspaceService {
     workspace.sessions = sessions;
     this.persistWorkspace(workspace);
   }
+
+  getMacOsTerminal(): string {
+    return this.workspace.macOsTerminal;
+  }
+  
+  updateMacOsTerminal(macOsTerminal: string) {
+    const workspace = this.getWorkspace();
+    workspace.macOsTerminal = macOsTerminal;
+    this.persistWorkspace(workspace);
+  }
+  
 }


### PR DESCRIPTION

**Changelog**

There's now the possibility to select between MacOs Terminal or iTerm2 for opening an SSM session.
This resolves #176 .

![image](https://user-images.githubusercontent.com/5127047/138524064-53eeda14-6493-46fc-a936-f078f1444bfb.png)


