### PR TITLE
Bump homebrew cask automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,17 @@
+on:
+  push:
+    tags: 'v*'
+
+jobs:
+  homebrew:
+    name: Bump Homebrew formula
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mislav/bump-homebrew-formula-action@v1
+        with:
+          # A PR will be sent to github.com/Homebrew/homebrew-cask to update this formula:
+          formula-name: leapp
+          formula-path: Casks/leapp.rb
+          homebrew-tap: Homebrew/homebrew-cask
+        env:
+          COMMITTER_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Changelog**

N/A

**Bugfixes**

N/A

**Enhancements**

* Automatically bump homebew formula

**Notes**

* Closes https://github.com/Noovolari/leapp/issues/192
* Prevent having to manually bump for releases https://github.com/Homebrew/homebrew-cask/pull/118147
* Weird... one of the release notes is that it's already bumping the formula automatically but this file is empty https://github.com/Noovolari/leapp/blob/cc30a12c37fbb4ae35a7c3fdbc147c75f8d28a86/.github/workflows/brew.yml