### PR TITLE
docs: Update URLs to installation docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ All the covered access methods can be found [here](https://docs.leapp.cloud/use-
 
 
 # Installation
-Get [here](https://www.leapp.cloud/releases) the latest release.
+
+- Verify that all [requirements](https://docs.leapp.cloud/installation/requirements/) are satisfied.
+- Follow the [installation documentation](https://docs.leapp.cloud/installation/install-leapp/). 
 
 # Contributing
 


### PR DESCRIPTION
**Enhancements**

Directly link the documentation for installing the app as the single source of truth. Improves the first impression when opening the repository to contribute :) (Context: Not everyone comes via the google -> website -> docs route)

**Notes**

Coming from the Hacker News thread: https://news.ycombinator.com/item?id=30102578 
