### PR TITLE
feat: add support for adfs as a saml identity provider

### DIFF
--- a/src/app/services/session/aws/methods/aws-iam-role-federated.service.ts
+++ b/src/app/services/session/aws/methods/aws-iam-role-federated.service.ts
@@ -164,6 +164,7 @@ export class AwsIamRoleFederatedService extends AwsSessionService {
       const filter = {
         urls: [
           'https://*.onelogin.com/*',
+          'https://*/adfs/ls/idpinitiatedsignon*',
           'https://*.okta.com/*',
           'https://accounts.google.com/ServiceLogin*',
           'https://login.microsoftonline.com/*',
@@ -181,6 +182,11 @@ export class AwsIamRoleFederatedService extends AwsSessionService {
         }
         // One Login
         if (details.url.indexOf('.onelogin.com/login') !== -1) {
+          idpWindow = null;
+          resolve(true);
+        }
+        // ADFS 2.0
+        if (details.url.indexOf('adfs/ls/idpinitiatedsignon') !== -1 && details.url.indexOf('loginToRp=urn:amazon:webservices') !== -1) {
           idpWindow = null;
           resolve(true);
         }


### PR DESCRIPTION
Signed-off-by: peteawood <build@duck.com>

**Changelog**

- Standard url for ADFS SAML Identity Provider supported for AWS IAM Role Federated sessions

**Enhancements**

Used the suggested approach in #200 to support the standard SAML 2.0 url used by ADFS 2.0 for NTLM authentication. The same url should be used by later versions of ADFS but this change has only been tested with 2.0.

The expected url format for ADFS is `https://<fqdn>/adfs/ls/IdpInitiatedSignOn.aspx.` For authentication with AWS, the query string `?loginToRp=urn:amazon:webservices` should be concatenated. 

By default the IdpInitiatedSignOnPage class accepts only the loginToRp parameter as a query string parameter but it is possible to modify the code to accept other query string parameters. 

Therefore the indexOf check in the code is split into 2 to support firstly the custom FQDN and secondly the loginToRp parameter appearing in a position other than the first query string parameter. The aspx extension is not included in the filter to support scenarios where url rewriting/the underlying framework has "beautified" the url.

**Notes**
References:

- ADFS, SAML and AWS
  - https://aws.amazon.com/blogs/security/how-to-implement-federated-api-and-cli-access-using-saml-2-0-and-ad-fs/
  - https://aws.amazon.com/blogs/security/enabling-federation-to-aws-using-windows-active-directory-adfs-and-saml-2-0/
  - https://aws.amazon.com/blogs/compute/enabling-identity-federation-with-ad-fs-3-0-and-amazon-appstream-2-0/
- ADFS Sign In
  -  https://docs.microsoft.com/en-us/previous-versions/adfs-2.0/ee895361(v=msdn.10)?redirectedfrom=MSDN