### PR TITLE
fix: Allow Windows installation without elevating privileges

### DIFF
--- a/packages/desktop-app/package.json
+++ b/packages/desktop-app/package.json
@@ -120,7 +120,7 @@
       "icon": "src/assets/images/Leapp.ico",
       "legalTrademarks": "beSharp",
       "publisherName": "beSharp",
-      "requestedExecutionLevel": "highestAvailable",
+      "requestedExecutionLevel": "asInvoker",
       "verifyUpdateCodeSignature": false,
       "certificateFile": "windows_sign_certificate.pfx"
     }


### PR DESCRIPTION
**Changelog**

Lowered User Account Control (UAC) required level in Windows version.

**Bugfixes**

Allows installation and usage if user doesn't have admin rights. #284

**Enhancements**

-

**Notes**

About different levels: https://docs.microsoft.com/en-us/cpp/build/reference/manifestuac-embeds-uac-information-in-manifest?view=msvc-170#remarks

If user belongs to Administrators group, installer will pop up an UAC window for privilege elevation, installation proceeds and application works.

If user does not belong to Administrators group but uses different account (eg. adm-user) for administrative tasks, installer will pop up the UAC window for privilege elevation, user needs to use adm-user credentials and application gets installed under adm-user's profile. When user starts the application, the UAC prompt will show up, user needs to provide adm-user credentials and application will start. Sessions doesn't work because for example user's non-elevated command prompt doesn't have access to adm-user's profile where session data is stored. So in that example user's AWS session data is under `C:\Users\user\.aws\` and as Leapp is running elevated, it has stored credentials under `C:\Users\adm-user\.aws\`.

I have built fixed versions and used them with "aws iam user" and "aws single sign-on" sessions since at least Leapp v0.8.0 and haven't had any problems so far.

I need help with testing this in different scenarios, eg. with user that has ability to elevate into admin without different credentials and with different cloud profiles.