### PR TITLE
feat: added configureable default webconsole timeout

### DIFF
--- a/docs/built-in-features/general-options.md
+++ b/docs/built-in-features/general-options.md
@@ -26,5 +26,12 @@ With this option, you can switch between light and dark theme, or use your syste
 
 ![](images/screens/newuxui/leapp-dark.png?style=center-img)
 
+## Default Webconsole Duration
+
+This option is used to set the default Webconsole session duration in hours.
+
+!!! Info
+
+    The minimum session duration is 1 hour, and can be set to a maximum of 12 hours. [Set session duration](https://docs.aws.amazon.com/singlesignon/latest/userguide/howtosessionduration.html){: target='_blank'}
 
 

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -271,9 +271,9 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.10.tgz",
-      "integrity": "sha512-0+sW7e3HjQbiHbj1NeU/vN8ornohYlacAfZIaXhdoGweQqgcNy69COVciYYqEXJ/v+9OBA7Frxm4CVAuNqKeNA==",
+      "version": "7.18.12",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.12.tgz",
+      "integrity": "sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==",
       "dependencies": {
         "@babel/types": "^7.18.10",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -1674,9 +1674,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.18.10.tgz",
-      "integrity": "sha512-j2HQCJuMbi88QftIb5zlRu3c7PU+sXNnscqsrjqegoGiCgXR569pEdben9vly5QHKL2ilYkfnSwu64zsZo/VYQ==",
+      "version": "7.18.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.18.12.tgz",
+      "integrity": "sha512-2vjjam0cum0miPkenUbQswKowuxs/NjMwIKEq0zwegRxXk12C9YOF9STXnaUptITOtOJHKHpzvvWYOjbm6tc0w==",
       "dev": true,
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.18.9",
@@ -11969,13 +11969,13 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
+      "integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       },
       "engines": {
@@ -12017,9 +12017,9 @@
       }
     },
     "node_modules/oclif/node_modules/@oclif/core": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.13.1.tgz",
-      "integrity": "sha512-vIrk0qJllAu+q/nzxXWx8QHN4/+hmkYqh0Qx1V2x3Nkun18wF7HfkIzgy1Ml0ZxDv1WA9AfL4MXvgbaQxVXQ+Q==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.13.3.tgz",
+      "integrity": "sha512-X7aThMtE7WB0HHejp0A/YUzxitDu0SUBcHLqbo+dTcgA/aWRtLBHIlIIHJcIeXa0Cvj+2U9BVcPDftrvEE/N2Q==",
       "dependencies": {
         "@oclif/linewrap": "^1.0.0",
         "@oclif/screen": "^3.0.2",
@@ -12821,9 +12821,9 @@
       }
     },
     "node_modules/prebuildify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/prebuildify/-/prebuildify-5.0.0.tgz",
-      "integrity": "sha512-XhuFIeZx8Tk8e8yn3h5e+CE572pecpdKPrVubUIW0HctP3fpzh4eSWoHR1eOoQNTtxBUt1ixPLHPLbOTYi6STw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/prebuildify/-/prebuildify-5.0.1.tgz",
+      "integrity": "sha512-vXpKLfIEsDCqMJWVIoSrUUBJQIuAk9uHAkLiGJuTdXdqKSJ10sHmWeuNCDkIoRFTV1BDGYMghHVmDFP8NfkA2Q==",
       "dev": true,
       "dependencies": {
         "execspawn": "^1.0.1",
@@ -16476,9 +16476,9 @@
       }
     },
     "@babel/generator": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.10.tgz",
-      "integrity": "sha512-0+sW7e3HjQbiHbj1NeU/vN8ornohYlacAfZIaXhdoGweQqgcNy69COVciYYqEXJ/v+9OBA7Frxm4CVAuNqKeNA==",
+      "version": "7.18.12",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.12.tgz",
+      "integrity": "sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==",
       "requires": {
         "@babel/types": "^7.18.10",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -17414,9 +17414,9 @@
       }
     },
     "@babel/plugin-transform-typescript": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.18.10.tgz",
-      "integrity": "sha512-j2HQCJuMbi88QftIb5zlRu3c7PU+sXNnscqsrjqegoGiCgXR569pEdben9vly5QHKL2ilYkfnSwu64zsZo/VYQ==",
+      "version": "7.18.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.18.12.tgz",
+      "integrity": "sha512-2vjjam0cum0miPkenUbQswKowuxs/NjMwIKEq0zwegRxXk12C9YOF9STXnaUptITOtOJHKHpzvvWYOjbm6tc0w==",
       "dev": true,
       "requires": {
         "@babel/helper-create-class-features-plugin": "^7.18.9",
@@ -25286,13 +25286,13 @@
       "integrity": "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A=="
     },
     "object.assign": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
+      "integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
       "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       }
     },
@@ -25322,9 +25322,9 @@
       },
       "dependencies": {
         "@oclif/core": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.13.1.tgz",
-          "integrity": "sha512-vIrk0qJllAu+q/nzxXWx8QHN4/+hmkYqh0Qx1V2x3Nkun18wF7HfkIzgy1Ml0ZxDv1WA9AfL4MXvgbaQxVXQ+Q==",
+          "version": "1.13.3",
+          "resolved": "https://registry.npmjs.org/@oclif/core/-/core-1.13.3.tgz",
+          "integrity": "sha512-X7aThMtE7WB0HHejp0A/YUzxitDu0SUBcHLqbo+dTcgA/aWRtLBHIlIIHJcIeXa0Cvj+2U9BVcPDftrvEE/N2Q==",
           "requires": {
             "@oclif/linewrap": "^1.0.0",
             "@oclif/screen": "^3.0.2",
@@ -25916,9 +25916,9 @@
       }
     },
     "prebuildify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/prebuildify/-/prebuildify-5.0.0.tgz",
-      "integrity": "sha512-XhuFIeZx8Tk8e8yn3h5e+CE572pecpdKPrVubUIW0HctP3fpzh4eSWoHR1eOoQNTtxBUt1ixPLHPLbOTYi6STw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/prebuildify/-/prebuildify-5.0.1.tgz",
+      "integrity": "sha512-vXpKLfIEsDCqMJWVIoSrUUBJQIuAk9uHAkLiGJuTdXdqKSJ10sHmWeuNCDkIoRFTV1BDGYMghHVmDFP8NfkA2Q==",
       "dev": true,
       "requires": {
         "execspawn": "^1.0.1",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -163,9 +163,9 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.10.tgz",
-      "integrity": "sha512-0+sW7e3HjQbiHbj1NeU/vN8ornohYlacAfZIaXhdoGweQqgcNy69COVciYYqEXJ/v+9OBA7Frxm4CVAuNqKeNA==",
+      "version": "7.18.12",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.12.tgz",
+      "integrity": "sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==",
       "dependencies": {
         "@babel/types": "^7.18.10",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -1568,9 +1568,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.18.10.tgz",
-      "integrity": "sha512-j2HQCJuMbi88QftIb5zlRu3c7PU+sXNnscqsrjqegoGiCgXR569pEdben9vly5QHKL2ilYkfnSwu64zsZo/VYQ==",
+      "version": "7.18.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.18.12.tgz",
+      "integrity": "sha512-2vjjam0cum0miPkenUbQswKowuxs/NjMwIKEq0zwegRxXk12C9YOF9STXnaUptITOtOJHKHpzvvWYOjbm6tc0w==",
       "dev": true,
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.18.9",
@@ -4752,9 +4752,9 @@
       }
     },
     "node_modules/constructs": {
-      "version": "10.1.67",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.67.tgz",
-      "integrity": "sha512-KhzH9QQmlgRRqwL5/+Arg/e9Nk7XAwYV4kBHNYf9cpRluACdaDSTJV2JPICwioWHSdkHoq8ChtQAgIq5KcNEnA==",
+      "version": "10.1.68",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.68.tgz",
+      "integrity": "sha512-UsWVyGg+6YMRTRiDr/+TGWaFJ5tYCEuiHonpYu+yY6z9hdmZ81NsA7jHkCrCq/iVHa5zsx9MEIQ/cYWnT4SZ7Q==",
       "dev": true,
       "peer": true,
       "engines": {
@@ -10466,13 +10466,13 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
+      "integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       },
       "engines": {
@@ -13527,9 +13527,9 @@
       }
     },
     "@babel/generator": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.10.tgz",
-      "integrity": "sha512-0+sW7e3HjQbiHbj1NeU/vN8ornohYlacAfZIaXhdoGweQqgcNy69COVciYYqEXJ/v+9OBA7Frxm4CVAuNqKeNA==",
+      "version": "7.18.12",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.12.tgz",
+      "integrity": "sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==",
       "requires": {
         "@babel/types": "^7.18.10",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -14467,9 +14467,9 @@
       }
     },
     "@babel/plugin-transform-typescript": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.18.10.tgz",
-      "integrity": "sha512-j2HQCJuMbi88QftIb5zlRu3c7PU+sXNnscqsrjqegoGiCgXR569pEdben9vly5QHKL2ilYkfnSwu64zsZo/VYQ==",
+      "version": "7.18.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.18.12.tgz",
+      "integrity": "sha512-2vjjam0cum0miPkenUbQswKowuxs/NjMwIKEq0zwegRxXk12C9YOF9STXnaUptITOtOJHKHpzvvWYOjbm6tc0w==",
       "dev": true,
       "requires": {
         "@babel/helper-create-class-features-plugin": "^7.18.9",
@@ -16916,9 +16916,9 @@
       }
     },
     "constructs": {
-      "version": "10.1.67",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.67.tgz",
-      "integrity": "sha512-KhzH9QQmlgRRqwL5/+Arg/e9Nk7XAwYV4kBHNYf9cpRluACdaDSTJV2JPICwioWHSdkHoq8ChtQAgIq5KcNEnA==",
+      "version": "10.1.68",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.68.tgz",
+      "integrity": "sha512-UsWVyGg+6YMRTRiDr/+TGWaFJ5tYCEuiHonpYu+yY6z9hdmZ81NsA7jHkCrCq/iVHa5zsx9MEIQ/cYWnT4SZ7Q==",
       "dev": true,
       "peer": true
     },
@@ -21176,13 +21176,13 @@
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
+      "integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
       "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       }
     },

--- a/packages/core/src/models/workspace.spec.ts
+++ b/packages/core/src/models/workspace.spec.ts
@@ -239,4 +239,16 @@ describe("Workspace Model", () => {
     workspace.pluginsStatus = mock;
     expect(mock).toStrictEqual((workspace as any)._pluginsStatus);
   });
+
+  test("samlRoleSessionDuration", () => {
+    const workspace = new Workspace();
+    expect(workspace.samlRoleSessionDuration).toStrictEqual((workspace as any)._samlRoleSessionDuration);
+  });
+
+  test("set samlRoleSessionDuration", () => {
+    const workspace = new Workspace();
+    const mock = { mock: "mock" } as any;
+    workspace.samlRoleSessionDuration = mock;
+    expect(mock).toStrictEqual((workspace as any)._samlRoleSessionDuration);
+  });
 });

--- a/packages/core/src/models/workspace.ts
+++ b/packages/core/src/models/workspace.ts
@@ -42,6 +42,7 @@ export class Workspace {
   };
 
   private _credentialMethod: string;
+  private _samlRoleSessionDuration: number;
 
   private _workspaceVersion: number;
 
@@ -69,6 +70,7 @@ export class Workspace {
     };
 
     this._credentialMethod = constants.credentialFile;
+    this._samlRoleSessionDuration = constants.samlRoleSessionDuration;
   }
 
   setNewWorkspaceVersion(): void {
@@ -197,5 +199,13 @@ export class Workspace {
 
   set pluginsStatus(newPlugins: PluginStatus[]) {
     this._pluginsStatus = newPlugins;
+  }
+
+  get samlRoleSessionDuration(): number {
+    return this._samlRoleSessionDuration;
+  }
+
+  set samlRoleSessionDuration(duration: number) {
+    this._samlRoleSessionDuration = duration;
   }
 }

--- a/packages/desktop-app/package-lock.json
+++ b/packages/desktop-app/package-lock.json
@@ -693,9 +693,9 @@
       }
     },
     "node_modules/@angular/compiler-cli/node_modules/@babel/generator": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.10.tgz",
-      "integrity": "sha512-0+sW7e3HjQbiHbj1NeU/vN8ornohYlacAfZIaXhdoGweQqgcNy69COVciYYqEXJ/v+9OBA7Frxm4CVAuNqKeNA==",
+      "version": "7.18.12",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.12.tgz",
+      "integrity": "sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.10",
@@ -2636,9 +2636,9 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/@babel/generator": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.10.tgz",
-      "integrity": "sha512-0+sW7e3HjQbiHbj1NeU/vN8ornohYlacAfZIaXhdoGweQqgcNy69COVciYYqEXJ/v+9OBA7Frxm4CVAuNqKeNA==",
+      "version": "7.18.12",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.12.tgz",
+      "integrity": "sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.10",
@@ -12936,9 +12936,9 @@
       }
     },
     "node_modules/gushio/node_modules/@babel/generator": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.10.tgz",
-      "integrity": "sha512-0+sW7e3HjQbiHbj1NeU/vN8ornohYlacAfZIaXhdoGweQqgcNy69COVciYYqEXJ/v+9OBA7Frxm4CVAuNqKeNA==",
+      "version": "7.18.12",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.12.tgz",
+      "integrity": "sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.10",
@@ -18064,13 +18064,13 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
+      "integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       },
       "engines": {
@@ -18796,14 +18796,14 @@
       }
     },
     "node_modules/portfinder": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
-      "integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
+      "version": "1.0.29",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.29.tgz",
+      "integrity": "sha512-Z5+DarHWCKlufshB9Z1pN95oLtANoY5Wn9X3JGELGyQ6VhEcBfT2t+1fGUBq7MwUant6g/mqowH+4HifByPbiQ==",
       "dev": true,
       "dependencies": {
-        "async": "^2.6.2",
-        "debug": "^3.1.1",
-        "mkdirp": "^0.5.5"
+        "async": "^2.6.4",
+        "debug": "^3.2.7",
+        "mkdirp": "^0.5.6"
       },
       "engines": {
         "node": ">= 0.12.0"
@@ -24701,9 +24701,9 @@
           }
         },
         "@babel/generator": {
-          "version": "7.18.10",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.10.tgz",
-          "integrity": "sha512-0+sW7e3HjQbiHbj1NeU/vN8ornohYlacAfZIaXhdoGweQqgcNy69COVciYYqEXJ/v+9OBA7Frxm4CVAuNqKeNA==",
+          "version": "7.18.12",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.12.tgz",
+          "integrity": "sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.18.10",
@@ -26067,9 +26067,9 @@
       },
       "dependencies": {
         "@babel/generator": {
-          "version": "7.18.10",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.10.tgz",
-          "integrity": "sha512-0+sW7e3HjQbiHbj1NeU/vN8ornohYlacAfZIaXhdoGweQqgcNy69COVciYYqEXJ/v+9OBA7Frxm4CVAuNqKeNA==",
+          "version": "7.18.12",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.12.tgz",
+          "integrity": "sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.18.10",
@@ -33985,9 +33985,9 @@
           }
         },
         "@babel/generator": {
-          "version": "7.18.10",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.10.tgz",
-          "integrity": "sha512-0+sW7e3HjQbiHbj1NeU/vN8ornohYlacAfZIaXhdoGweQqgcNy69COVciYYqEXJ/v+9OBA7Frxm4CVAuNqKeNA==",
+          "version": "7.18.12",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.12.tgz",
+          "integrity": "sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.18.10",
@@ -37867,13 +37867,13 @@
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.3.tgz",
+      "integrity": "sha512-ZFJnX3zltyjcYJL0RoCJuzb+11zWGyaDbjgxZbdV7rFEcHQuYxrZqhow67aA7xpes6LhojyFDaBKAFfogQrikA==",
       "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       }
     },
@@ -38436,14 +38436,14 @@
       "peer": true
     },
     "portfinder": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
-      "integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
+      "version": "1.0.29",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.29.tgz",
+      "integrity": "sha512-Z5+DarHWCKlufshB9Z1pN95oLtANoY5Wn9X3JGELGyQ6VhEcBfT2t+1fGUBq7MwUant6g/mqowH+4HifByPbiQ==",
       "dev": true,
       "requires": {
-        "async": "^2.6.2",
-        "debug": "^3.1.1",
-        "mkdirp": "^0.5.5"
+        "async": "^2.6.4",
+        "debug": "^3.2.7",
+        "mkdirp": "^0.5.6"
       },
       "dependencies": {
         "async": {

--- a/packages/desktop-app/src/app/components/dialogs/options-dialog/options-dialog.component.html
+++ b/packages/desktop-app/src/app/components/dialogs/options-dialog/options-dialog.component.html
@@ -87,6 +87,17 @@
           </div>
         </ng-container>
 
+        <h2>Default Webconsole Duration</h2>
+        <div class="form-container">
+          <div class="form-group">
+            <div class="form-field">
+              <label><i class="moon-Help fix-top"
+                matTooltip="Note: The minimum session duration is 1 hour, and can be set to a maximum of 12 hours."></i>&nbsp;Session Time</label>
+              <input formControlName="sessionDuration" type="number" class="form-control" min="1" max="12" step="1" [value]="webConsoleSessionDuration">
+            </div>
+          </div>
+        </div>
+
         <hr class="proxy-settings-section">
 
         <h2 class="proxy-settings-section">Proxy settings</h2>

--- a/packages/desktop-app/src/app/components/dialogs/options-dialog/options-dialog.component.ts
+++ b/packages/desktop-app/src/app/components/dialogs/options-dialog/options-dialog.component.ts
@@ -74,10 +74,12 @@ export class OptionsDialogComponent implements OnInit, AfterViewInit {
     terminalSelect: new FormControl(""),
     colorThemeSelect: new FormControl(""),
     credentialMethodSelect: new FormControl(""),
+    sessionDuration: new FormControl(""),
     pluginDeepLink: new FormControl(""),
   });
 
   selectedCredentialMethod: string;
+  webConsoleSessionDuration: number;
 
   /* Simple profile page: shows the Idp Url and the workspace json */
   private sessionService: SessionService;
@@ -108,6 +110,7 @@ export class OptionsDialogComponent implements OnInit, AfterViewInit {
     this.proxyPort = this.optionsService.proxyConfiguration.proxyPort;
     this.proxyUsername = this.optionsService.proxyConfiguration.username || "";
     this.proxyPassword = this.optionsService.proxyConfiguration.password || "";
+    this.webConsoleSessionDuration = this.optionsService.samlRoleSessionDuration || constants.samlRoleSessionDuration;
 
     this.form.controls["idpUrl"].setValue(this.idpUrlValue);
     this.form.controls["proxyUrl"].setValue(this.proxyUrl);
@@ -115,6 +118,7 @@ export class OptionsDialogComponent implements OnInit, AfterViewInit {
     this.form.controls["proxyPort"].setValue(this.proxyPort);
     this.form.controls["proxyUsername"].setValue(this.proxyUsername);
     this.form.controls["proxyPassword"].setValue(this.proxyPassword);
+    this.form.controls["sessionDuration"].setValue(this.webConsoleSessionDuration);
 
     const isProxyUrl = this.optionsService.proxyConfiguration.proxyUrl && this.optionsService.proxyConfiguration.proxyUrl !== "undefined";
     this.proxyUrl = isProxyUrl ? this.optionsService.proxyConfiguration.proxyUrl : "";
@@ -168,6 +172,7 @@ export class OptionsDialogComponent implements OnInit, AfterViewInit {
       this.optionsService.defaultRegion = this.selectedRegion;
       this.optionsService.defaultLocation = this.selectedLocation;
       this.optionsService.macOsTerminal = this.selectedTerminal;
+      this.optionsService.samlRoleSessionDuration = this.form.controls["sessionDuration"].value;
 
       if (this.checkIfNeedDialogBox()) {
         // eslint-disable-next-line max-len

--- a/packages/desktop-app/src/app/components/sessions/session-card/session-card.component.ts
+++ b/packages/desktop-app/src/app/components/sessions/session-card/session-card.component.ts
@@ -285,7 +285,8 @@ export class SessionCardComponent implements OnInit {
     try {
       const credentials = await (this.sessionService as AwsSessionService).generateCredentials(this.session.sessionId);
       const sessionRegion = this.session.region;
-      const loginURL = await this.appProviderService.webConsoleService.getWebConsoleUrl(credentials, sessionRegion);
+      const sessionDuration = this.appProviderService.workspaceService.getWorkspace().samlRoleSessionDuration;
+      const loginURL = await this.appProviderService.webConsoleService.getWebConsoleUrl(credentials, sessionRegion, sessionDuration);
 
       this.appService.copyToClipboard(loginURL);
       this.messageToasterService.toast("Your information has been successfully copied!", ToastLevel.success, "Information copied!");
@@ -573,7 +574,8 @@ export class SessionCardComponent implements OnInit {
     this.trigger.closeMenu();
     const credentials = await (this.sessionService as AwsSessionService).generateCredentials(this.session.sessionId);
     const sessionRegion = this.session.region;
-    await this.appProviderService.webConsoleService.openWebConsole(credentials, sessionRegion);
+    const sessionDuration = this.appProviderService.workspaceService.getWorkspace().samlRoleSessionDuration;
+    await this.appProviderService.webConsoleService.openWebConsole(credentials, sessionRegion, sessionDuration);
   }
 
   createAChainedSessionFromSelectedOne(): void {

--- a/packages/desktop-app/src/app/services/options.service.ts
+++ b/packages/desktop-app/src/app/services/options.service.ts
@@ -115,4 +115,15 @@ export class OptionsService {
       this.workspaceService.persistWorkspace(workspace);
     }
   }
+
+  get samlRoleSessionDuration(): number {
+    const workspace = this.workspaceService.getWorkspace();
+    return workspace.samlRoleSessionDuration / 60 / 60;
+  }
+
+  set samlRoleSessionDuration(value: number) {
+    const workspace = this.workspaceService.getWorkspace();
+    workspace.samlRoleSessionDuration = value * 60 * 60;
+    this.workspaceService.persistWorkspace(workspace);
+  }
 }


### PR DESCRIPTION
**Changelog**

Core:

- feat: made `samlRoleSessionDuration` configurable

Desktop-app:

- feat: added new option to the `General options`.
- feat: webconsole sessions are configurable between 1 and 12 hours.

**Bugfixes**

Describe the fixes and specifying the issue if related.

**Enhancements**

a new option is added in the general options with which the default webconsole timeout can be configured between 1 hour and 12 hours. #283 

**Notes**

- Does this need to be implemented for CLI as well?

Screenshots:
Example General options:
<img width="533" alt="Screenshot 2022-08-07 at 01 08 44" src="https://user-images.githubusercontent.com/91890716/183268630-140e7465-0243-4983-ae5d-a1afa373ce41.png">

Webconsole session request when default duration is set to 2 hours:
<img width="437" alt="Screenshot 2022-08-07 at 01 14 17" src="https://user-images.githubusercontent.com/91890716/183268753-740091b0-708d-4f66-b015-4531096210e4.png">