### PR TITLE
feat: add support to use Auth0 as SAML IdP

### DIFF
--- a/packages/core/src/services/aws-saml-assertion-extraction-service.spec.ts
+++ b/packages/core/src/services/aws-saml-assertion-extraction-service.spec.ts
@@ -25,6 +25,12 @@ describe("AwsSamlAssertionExtractionService", () => {
     expect(service.isAuthenticationUrl(CloudProviderType.aws, "https://login.microsoftonline.com")).toBe(false);
 
     expect(service.isAuthenticationUrl(CloudProviderType.aws, "https://signin.aws.amazon.com/saml")).toBe(false);
+
+    expect(service.isAuthenticationUrl(CloudProviderType.aws, "https://tenant-name.us.auth0.com/samlp/client-id")).toBe(true);
+    expect(service.isAuthenticationUrl(CloudProviderType.aws, "https://tenant-name.us.auth0.com")).toBe(false);
+    expect(service.isAuthenticationUrl(CloudProviderType.aws, "https://tenant-name.us.auth0.com/samlp/")).toBe(false);
+    expect(service.isAuthenticationUrl(CloudProviderType.aws, "https://.auth0.com/samlp/")).toBe(false);
+    expect(service.isAuthenticationUrl(CloudProviderType.aws, "https://auth0.com/samlp/")).toBe(false);
   });
 
   test("isSamlAssertionUrl", () => {

--- a/packages/core/src/services/aws-saml-assertion-extraction-service.ts
+++ b/packages/core/src/services/aws-saml-assertion-extraction-service.ts
@@ -14,6 +14,7 @@ const authenticationUrlRegexes = new Map([
       /^https:\/\/login\.okta\.com\/.*/,
       /^https:\/\/accounts\.google\.com\/ServiceLogin.*/,
       /^https:\/\/login\.microsoftonline\.com\/*.*\/oauth2\/authorize.*/,
+      /^https:\/\/.+\.auth0\.com\/samlp\/.+/,
     ],
   ],
 ]);


### PR DESCRIPTION
Signed-off-by: Massimo Maino <massimo.maino@claudacademy.com>

**Changelog**

Add Auth0 IdP URL filter

**Enhancements**

Add support to use Auth0 as SAML IdP. Ref [https://auth0.com/docs/customize/integrations/aws/configure-amazon-web-services-for-sso](https://auth0.com/docs/customize/integrations/aws/configure-amazon-web-services-for-sso
)