### PR TITLE
fix: issue #340

### DIFF
--- a/packages/cli/src/commands/session/run-aws-credential-plugin.ts
+++ b/packages/cli/src/commands/session/run-aws-credential-plugin.ts
@@ -29,6 +29,7 @@ export default class RunAwsCredentialPlugin extends LeappCommand {
         if (!selectedSession) {
           throw new Error("No session found with id " + flags.sessionId);
         }
+        await this.cliProviderService.pluginManagerService.loadFromPluginDir();
         const selectedPlugin = this.cliProviderService.pluginManagerService
           .availableAwsCredentialsPlugins(os, selectedSession)
           .find((plugin) => plugin.metadata.uniqueName === flags.pluginName);


### PR DESCRIPTION
Missing initialization of plugins when running from CLI with flags


**Bugfixes**

This is related to issue #340 by @bibli-alex. 

Please confirm the functionality  


