### PR TITLE
fix(#360): recreates AWS SSO client when the region changes

### DIFF
--- a/packages/core/src/services/integration/aws-sso-integration-service.ts
+++ b/packages/core/src/services/integration/aws-sso-integration-service.ts
@@ -297,7 +297,7 @@ export class AwsSsoIntegrationService implements IIntegrationService {
   }
 
   private setupSsoPortalClient(region: string): void {
-    if (!this.ssoPortal) {
+    if (!this.ssoPortal || this.ssoPortal.config.region !== region) {
       this.ssoPortal = new SSO({ region });
       this.listAccountRolesCall = new ThrottleService((...params) => this.ssoPortal.listAccountRoles(...params).promise(), constants.maxSsoTps);
     }


### PR DESCRIPTION
This commit fixes the case when the region for AWS SSO changes and the client isn't aware, leading to the "Session token not found or invalid" error.

It adds a check to see if the clients' region is different to the integration one and so recreate the client.

Signed-off-by: Mauricio Wyler <mwyler@ebowe.com>

**Changelog**

If SSO region changes the AWS SSO client is recreated

**Bugfixes**

[#360 ](url)
