### PR TITLE
fix(#374): support keycloak idp

### DIFF
--- a/packages/core/src/services/aws-saml-assertion-extraction-service.spec.ts
+++ b/packages/core/src/services/aws-saml-assertion-extraction-service.spec.ts
@@ -31,6 +31,9 @@ describe("AwsSamlAssertionExtractionService", () => {
     expect(service.isAuthenticationUrl(CloudProviderType.aws, "https://tenant-name.us.auth0.com/samlp/")).toBe(false);
     expect(service.isAuthenticationUrl(CloudProviderType.aws, "https://.auth0.com/samlp/")).toBe(false);
     expect(service.isAuthenticationUrl(CloudProviderType.aws, "https://auth0.com/samlp/")).toBe(false);
+
+    /* Tests for keycloak Identity Providers */
+    expect(service.isAuthenticationUrl(CloudProviderType.aws, "https://XX/auth/realms/XX/protocol/saml/clients/XX")).toBe(true);
   });
 
   test("isSamlAssertionUrl", () => {

--- a/packages/core/src/services/aws-saml-assertion-extraction-service.ts
+++ b/packages/core/src/services/aws-saml-assertion-extraction-service.ts
@@ -15,6 +15,7 @@ const authenticationUrlRegexes = new Map([
       /^https:\/\/accounts\.google\.com\/ServiceLogin.*/,
       /^https:\/\/login\.microsoftonline\.com\/*.*\/oauth2\/authorize.*/,
       /^https:\/\/.+\.auth0\.com\/samlp\/.+/,
+      /^https:\/\/.*\/auth\/realms\/.*\/protocol\/saml\/clients\/.*/,
     ],
   ],
 ]);


### PR DESCRIPTION
**Changelog**

Fixes #374: patched `core` to support Keycloak URL

**Enhancements**

Authenticating through Keycloak Identity Provider now supported
