### PR TITLE
feat(ci): add brew bump CI

### DIFF
--- a/.github/workflows/desktop-app-brew.yml
+++ b/.github/workflows/desktop-app-brew.yml
@@ -1,0 +1,18 @@
+name: Leapp Desktop App Brew bump
+
+on:
+  workflow_run:
+    workflows: ["Leapp Desktop App CD"]
+    branches: [main]
+    types:
+      - completed
+
+jobs:
+    runs-on: macos-latest
+    steps:
+      - name: Bump Brew
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.BREW_TOKEN }}
+        run: |
+          TAG=$(git tag --points-at $GITHUB_SHA)
+          brew bump-cask-pr leapp --version=$TAG --no-browse --no-audit


### PR DESCRIPTION
**Changelog**

Add a GitHub workflow to automatically update the version on the [brew repository ](https://github.com/Homebrew/homebrew-cask). 
This workflow depends on the `Leapp Desktop App CD` one before starting.

**Bugfixes**

Avoid generating PR manually with bump-cask-pr

**Enhancements**

Provide an immediate PR to bump ASAP the version on brew. This will reduce the risk that users install the app through brew but have to update it immediately since it could already be old.

**Notes**

Inspiration taken from this post [github actions + homebrew = ❤️](https://extrawurst.medium.com/github-actions-homebrew-%EF%B8%8F-2789ae5023fd)

TODO: 

- [ ] A GitHub secret must be add in the repository under this variable `BREW_TOKEN`