### PR TITLE
320 trust system ca

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -57,6 +57,7 @@
         "semver": "~7.3.5",
         "standard-version": "^9.3.0",
         "sudo-prompt": "~9.2.1",
+        "system-ca": "^1.0.2",
         "tar": "^6.1.11",
         "tslib": "^2.3.1",
         "uuid": "~8.3.2",
@@ -4434,6 +4435,15 @@
         "url": "https://bevry.me/fund"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bl": {
       "version": "5.1.0",
       "dev": true,
@@ -7086,6 +7096,12 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "node_modules/filelist": {
       "version": "1.0.4",
@@ -10605,6 +10621,20 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/macos-export-certificate-and-key": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/macos-export-certificate-and-key/-/macos-export-certificate-and-key-1.1.1.tgz",
+      "integrity": "sha512-J2g0dJRLG3DghmdCkbJnif/zPmSylj6ql//xBYff5allzNlHPnWxRoyho9XznBYLbPJw4jZlKjMO69jtV8VC7Q==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^4.3.0"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "dev": true,
@@ -11245,6 +11275,15 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "optional": true,
+      "engines": {
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-gyp": {
@@ -14183,6 +14222,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/system-ca": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/system-ca/-/system-ca-1.0.2.tgz",
+      "integrity": "sha512-/6CCJOKB5Fpi0x7/DCbV7uiFPgwGCeJsAaSondXS2DjLBv7ER2worVGvQWJqPM0kgOKO6auaCcSWpJKnrDmXjw==",
+      "optionalDependencies": {
+        "macos-export-certificate-and-key": "^1.1.1",
+        "win-export-certificate-and-key": "^1.1.1"
+      }
+    },
     "node_modules/table": {
       "version": "6.8.1",
       "dev": true,
@@ -15160,6 +15208,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/win-export-certificate-and-key": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/win-export-certificate-and-key/-/win-export-certificate-and-key-1.1.1.tgz",
+      "integrity": "sha512-wvF1DKlbt/PLOSdnKzIqv0Ipj+87n2VYOJFbkqBoN7l3l244reT7Lf6+Dnu86bYVWoVpq3ZZG417OLNHFnkP6A==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^4.3.0",
+        "node-forge": "^1.2.1"
       }
     },
     "node_modules/word-wrap": {
@@ -18501,6 +18564,15 @@
     "binaryextensions": {
       "version": "4.18.0"
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "5.1.0",
       "dev": true,
@@ -20131,6 +20203,12 @@
       "requires": {
         "flat-cache": "^3.0.4"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "filelist": {
       "version": "1.0.4",
@@ -22371,6 +22449,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "macos-export-certificate-and-key": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/macos-export-certificate-and-key/-/macos-export-certificate-and-key-1.1.1.tgz",
+      "integrity": "sha512-J2g0dJRLG3DghmdCkbJnif/zPmSylj6ql//xBYff5allzNlHPnWxRoyho9XznBYLbPJw4jZlKjMO69jtV8VC7Q==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^4.3.0"
+      }
+    },
     "make-dir": {
       "version": "3.1.0",
       "dev": true,
@@ -22785,6 +22873,12 @@
           }
         }
       }
+    },
+    "node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "optional": true
     },
     "node-gyp": {
       "version": "8.4.1",
@@ -24616,6 +24710,15 @@
       "version": "3.2.4",
       "dev": true
     },
+    "system-ca": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/system-ca/-/system-ca-1.0.2.tgz",
+      "integrity": "sha512-/6CCJOKB5Fpi0x7/DCbV7uiFPgwGCeJsAaSondXS2DjLBv7ER2worVGvQWJqPM0kgOKO6auaCcSWpJKnrDmXjw==",
+      "requires": {
+        "macos-export-certificate-and-key": "^1.1.1",
+        "win-export-certificate-and-key": "^1.1.1"
+      }
+    },
     "table": {
       "version": "6.8.1",
       "dev": true,
@@ -25245,6 +25348,17 @@
       "version": "3.1.0",
       "requires": {
         "string-width": "^4.0.0"
+      }
+    },
+    "win-export-certificate-and-key": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/win-export-certificate-and-key/-/win-export-certificate-and-key-1.1.1.tgz",
+      "integrity": "sha512-wvF1DKlbt/PLOSdnKzIqv0Ipj+87n2VYOJFbkqBoN7l3l244reT7Lf6+Dnu86bYVWoVpq3ZZG417OLNHFnkP6A==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^4.3.0",
+        "node-forge": "^1.2.1"
       }
     },
     "word-wrap": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -60,6 +60,7 @@
     "semver": "~7.3.5",
     "standard-version": "^9.3.0",
     "sudo-prompt": "~9.2.1",
+    "system-ca": "^1.0.2",
     "tar": "^6.1.11",
     "tslib": "^2.3.1",
     "uuid": "~8.3.2",

--- a/packages/cli/src/service/cli-native-service.ts
+++ b/packages/cli/src/service/cli-native-service.ts
@@ -15,6 +15,7 @@ export class CliNativeService implements INativeService {
   semver: any;
   machineId: any;
   keytar: any;
+  systemCertsAsync: any;
   followRedirects: any;
   httpProxyAgent: any;
   httpsProxyAgent: any;
@@ -44,6 +45,7 @@ export class CliNativeService implements INativeService {
     this.semver = require("semver");
     this.machineId = require("node-machine-id").machineIdSync();
     this.keytar = require("keytar");
+    this.systemCertsAsync = require("system-ca").systemCertsAsync;
     this.followRedirects = require("follow-redirects");
     this.httpProxyAgent = require("http-proxy-agent");
     this.httpsProxyAgent = require("https-proxy-agent");

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -64,6 +64,7 @@
         "semver": "~7.3.5",
         "standard-version": "^9.3.0",
         "sudo-prompt": "~9.2.1",
+        "system-ca": "^1.0.2",
         "tar": "^6.1.11",
         "tslib": "^2.3.1",
         "uuid": "~8.3.2",
@@ -4360,6 +4361,16 @@
         }
       ]
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bl": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
@@ -6152,6 +6163,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -10088,6 +10106,21 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/macos-export-certificate-and-key": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/macos-export-certificate-and-key/-/macos-export-certificate-and-key-1.1.1.tgz",
+      "integrity": "sha512-J2g0dJRLG3DghmdCkbJnif/zPmSylj6ql//xBYff5allzNlHPnWxRoyho9XznBYLbPJw4jZlKjMO69jtV8VC7Q==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^4.3.0"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -10459,6 +10492,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-int64": {
@@ -12567,6 +12610,16 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "node_modules/system-ca": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/system-ca/-/system-ca-1.0.2.tgz",
+      "integrity": "sha512-/6CCJOKB5Fpi0x7/DCbV7uiFPgwGCeJsAaSondXS2DjLBv7ER2worVGvQWJqPM0kgOKO6auaCcSWpJKnrDmXjw==",
+      "peer": true,
+      "optionalDependencies": {
+        "macos-export-certificate-and-key": "^1.1.1",
+        "win-export-certificate-and-key": "^1.1.1"
+      }
+    },
     "node_modules/tar": {
       "version": "6.1.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
@@ -13373,6 +13426,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/win-export-certificate-and-key": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/win-export-certificate-and-key/-/win-export-certificate-and-key-1.1.1.tgz",
+      "integrity": "sha512-wvF1DKlbt/PLOSdnKzIqv0Ipj+87n2VYOJFbkqBoN7l3l244reT7Lf6+Dnu86bYVWoVpq3ZZG417OLNHFnkP6A==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^4.3.0",
+        "node-forge": "^1.2.1"
       }
     },
     "node_modules/word-wrap": {
@@ -16839,6 +16908,16 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
@@ -18167,6 +18246,13 @@
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true,
+      "peer": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -21085,6 +21171,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "macos-export-certificate-and-key": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/macos-export-certificate-and-key/-/macos-export-certificate-and-key-1.1.1.tgz",
+      "integrity": "sha512-J2g0dJRLG3DghmdCkbJnif/zPmSylj6ql//xBYff5allzNlHPnWxRoyho9XznBYLbPJw4jZlKjMO69jtV8VC7Q==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^4.3.0"
+      }
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -21364,6 +21461,13 @@
         "fetch-blob": "^3.1.4",
         "formdata-polyfill": "^4.0.10"
       }
+    },
+    "node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "optional": true,
+      "peer": true
     },
     "node-int64": {
       "version": "0.4.0",
@@ -22967,6 +23071,16 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "system-ca": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/system-ca/-/system-ca-1.0.2.tgz",
+      "integrity": "sha512-/6CCJOKB5Fpi0x7/DCbV7uiFPgwGCeJsAaSondXS2DjLBv7ER2worVGvQWJqPM0kgOKO6auaCcSWpJKnrDmXjw==",
+      "peer": true,
+      "requires": {
+        "macos-export-certificate-and-key": "^1.1.1",
+        "win-export-certificate-and-key": "^1.1.1"
+      }
+    },
     "tar": {
       "version": "6.1.13",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
@@ -23583,6 +23697,18 @@
         "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0",
         "is-typed-array": "^1.1.10"
+      }
+    },
+    "win-export-certificate-and-key": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/win-export-certificate-and-key/-/win-export-certificate-and-key-1.1.1.tgz",
+      "integrity": "sha512-wvF1DKlbt/PLOSdnKzIqv0Ipj+87n2VYOJFbkqBoN7l3l244reT7Lf6+Dnu86bYVWoVpq3ZZG417OLNHFnkP6A==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^4.3.0",
+        "node-forge": "^1.2.1"
       }
     },
     "word-wrap": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,6 +45,7 @@
     "semver": "~7.3.5",
     "standard-version": "^9.3.0",
     "sudo-prompt": "~9.2.1",
+    "system-ca": "^1.0.2",
     "tar": "^6.1.11",
     "tslib": "^2.3.1",
     "uuid": "~8.3.2",

--- a/packages/core/src/interfaces/i-native-service.ts
+++ b/packages/core/src/interfaces/i-native-service.ts
@@ -15,6 +15,7 @@ export interface INativeService {
   semver: any;
   machineId: any;
   keytar: any;
+  systemCertsAsync: any;
   followRedirects: any;
   httpProxyAgent: any;
   httpsProxyAgent: any;

--- a/packages/core/src/models/aws/aws-sso-integration-creation-params.ts
+++ b/packages/core/src/models/aws/aws-sso-integration-creation-params.ts
@@ -4,4 +4,5 @@ export interface AwsSsoIntegrationCreationParams extends IntegrationParams {
   portalUrl: string;
   region: string;
   browserOpening: string;
+  trustSystemCA: boolean;
 }

--- a/packages/core/src/models/aws/aws-sso-integration.ts
+++ b/packages/core/src/models/aws/aws-sso-integration.ts
@@ -8,6 +8,7 @@ export class AwsSsoIntegration extends Integration {
     public portalUrl: string,
     public region: string,
     public browserOpening: string,
+    public trustSystemCA: boolean,
     public accessTokenExpiration: string
   ) {
     super(id, alias, IntegrationType.awsSso, false);

--- a/packages/core/src/services/integration/aws-sso-integration-service.ts
+++ b/packages/core/src/services/integration/aws-sso-integration-service.ts
@@ -280,9 +280,13 @@ export class AwsSsoIntegrationService implements IIntegrationService {
   }
 
   private async login(integrationId: string | number, region: string, portalUrl: string): Promise<LoginResponse> {
+    const systemCerts = await this.nativeService.systemCertsAsync();
+    const options = {
+      ca: systemCerts,
+    };
     const redirectClient = this.nativeService.followRedirects[this.getProtocol(portalUrl)];
     portalUrl = await new Promise((resolve, _) => {
-      const request = redirectClient.request(portalUrl, (response) => resolve(response.responseUrl));
+      const request = redirectClient.request(portalUrl, options, (response) => resolve(response.responseUrl));
       request.end();
     });
 

--- a/packages/core/src/services/integration/aws-sso-integration-service.ts
+++ b/packages/core/src/services/integration/aws-sso-integration-service.ts
@@ -55,7 +55,13 @@ export class AwsSsoIntegrationService implements IIntegrationService {
   }
 
   async createIntegration(creationParams: AwsSsoIntegrationCreationParams): Promise<void> {
-    this.repository.addAwsSsoIntegration(creationParams.portalUrl, creationParams.alias, creationParams.region, creationParams.browserOpening);
+    this.repository.addAwsSsoIntegration(
+      creationParams.portalUrl,
+      creationParams.alias,
+      creationParams.region,
+      creationParams.browserOpening,
+      creationParams.trustSystemCA
+    );
   }
 
   updateIntegration(id: string, updateParams: AwsSsoIntegrationCreationParams): void {
@@ -66,6 +72,7 @@ export class AwsSsoIntegrationService implements IIntegrationService {
       updateParams.region,
       updateParams.portalUrl,
       updateParams.browserOpening,
+      updateParams.trustSystemCA,
       isOnline
     );
   }
@@ -101,6 +108,7 @@ export class AwsSsoIntegrationService implements IIntegrationService {
       integration.region,
       integration.portalUrl,
       integration.browserOpening,
+      integration.trustSystemCA,
       integration.isOnline,
       integration.accessTokenExpiration
     );
@@ -210,6 +218,7 @@ export class AwsSsoIntegrationService implements IIntegrationService {
         region,
         loginResponse.portalUrlUnrolled,
         integration.browserOpening,
+        integration.trustSystemCA,
         loginResponse.expirationTime.toISOString(),
         loginResponse.accessToken
       );
@@ -263,11 +272,12 @@ export class AwsSsoIntegrationService implements IIntegrationService {
     region: string,
     portalUrl: string,
     browserOpening: string,
+    trustSystemCA: boolean,
     expirationTime: string,
     accessToken: string
   ): Promise<void> {
     const isOnline = this.repository.getAwsSsoIntegration(integrationId).isOnline;
-    this.repository.updateAwsSsoIntegration(integrationId, alias, region, portalUrl, browserOpening, isOnline, expirationTime);
+    this.repository.updateAwsSsoIntegration(integrationId, alias, region, portalUrl, browserOpening, trustSystemCA, isOnline, expirationTime);
     await this.keyChainService.saveSecret(constants.appName, this.getIntegrationAccessTokenKey(integrationId), accessToken);
   }
 
@@ -280,10 +290,14 @@ export class AwsSsoIntegrationService implements IIntegrationService {
   }
 
   private async login(integrationId: string | number, region: string, portalUrl: string): Promise<LoginResponse> {
-    const systemCerts = await this.nativeService.systemCertsAsync();
-    const options = {
-      ca: systemCerts,
-    };
+    const awsSsoIntegration = this.repository.getAwsSsoIntegration(integrationId);
+    let options = {};
+    if (awsSsoIntegration.trustSystemCA) {
+      const systemCerts = await this.nativeService.systemCertsAsync();
+      options = {
+        ca: systemCerts,
+      };
+    }
     const redirectClient = this.nativeService.followRedirects[this.getProtocol(portalUrl)];
     portalUrl = await new Promise((resolve, _) => {
       const request = redirectClient.request(portalUrl, options, (response) => resolve(response.responseUrl));

--- a/packages/core/src/services/repository.ts
+++ b/packages/core/src/services/repository.ts
@@ -274,9 +274,9 @@ export class Repository {
     return this.workspace.sessions.filter((sess) => (sess as any).awsSsoConfigurationId === id);
   }
 
-  addAwsSsoIntegration(portalUrl: string, alias: string, region: string, browserOpening: string): void {
+  addAwsSsoIntegration(portalUrl: string, alias: string, region: string, browserOpening: string, trustSystemCA: boolean): void {
     const workspace = this.getWorkspace();
-    workspace.awsSsoIntegrations.push(new AwsSsoIntegration(uuid.v4(), alias, portalUrl, region, browserOpening, undefined));
+    workspace.awsSsoIntegrations.push(new AwsSsoIntegration(uuid.v4(), alias, portalUrl, region, browserOpening, trustSystemCA, undefined));
     this.persistWorkspace(workspace);
   }
 
@@ -286,6 +286,7 @@ export class Repository {
     region: string,
     portalUrl: string,
     browserOpening: string,
+    trustSystemCA: boolean,
     isOnline: boolean,
     expirationTime?: string
   ): void {
@@ -296,6 +297,7 @@ export class Repository {
       workspace.awsSsoIntegrations[index].region = region;
       workspace.awsSsoIntegrations[index].portalUrl = portalUrl;
       workspace.awsSsoIntegrations[index].browserOpening = browserOpening;
+      workspace.awsSsoIntegrations[index].trustSystemCA = trustSystemCA;
       workspace.awsSsoIntegrations[index].isOnline = isOnline;
       if (expirationTime) {
         workspace.awsSsoIntegrations[index].accessTokenExpiration = expirationTime;

--- a/packages/core/src/services/retro-compatibility-service.ts
+++ b/packages/core/src/services/retro-compatibility-service.ts
@@ -112,6 +112,7 @@ export class RetroCompatibilityService {
             awsSsoConfiguration.portalUrl,
             awsSsoConfiguration.region,
             constants.inApp,
+            awsSsoConfiguration.trustSystemCA,
             awsSsoConfiguration.expirationTime
           )
         );
@@ -178,6 +179,7 @@ export class RetroCompatibilityService {
             awsSsoIntegrations[i].portalUrl,
             awsSsoIntegrations[i].region,
             awsSsoIntegrations[i].browserOpening,
+            awsSsoIntegrations[i].trustSystemCA,
             awsSsoIntegrations[i].accessTokenExpiration
           );
         } else {

--- a/packages/desktop-app/package-lock.json
+++ b/packages/desktop-app/package-lock.json
@@ -80,6 +80,7 @@
         "standard-version": "^9.3.0",
         "stream-browserify": "3.0.0",
         "sudo-prompt": "~9.2.1",
+        "system-ca": "^1.0.2",
         "tar": "^6.1.11",
         "tslib": "^2.3.1",
         "update-electron-app": "~2.0.1",
@@ -14953,6 +14954,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/macos-export-certificate-and-key": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/macos-export-certificate-and-key/-/macos-export-certificate-and-key-1.1.1.tgz",
+      "integrity": "sha512-J2g0dJRLG3DghmdCkbJnif/zPmSylj6ql//xBYff5allzNlHPnWxRoyho9XznBYLbPJw4jZlKjMO69jtV8VC7Q==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^4.3.0"
+      }
+    },
+    "node_modules/macos-export-certificate-and-key/node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "optional": true
+    },
     "node_modules/magic-string": {
       "version": "0.25.7",
       "dev": true,
@@ -20531,6 +20552,15 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/system-ca": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/system-ca/-/system-ca-1.0.2.tgz",
+      "integrity": "sha512-/6CCJOKB5Fpi0x7/DCbV7uiFPgwGCeJsAaSondXS2DjLBv7ER2worVGvQWJqPM0kgOKO6auaCcSWpJKnrDmXjw==",
+      "optionalDependencies": {
+        "macos-export-certificate-and-key": "^1.1.1",
+        "win-export-certificate-and-key": "^1.1.1"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "dev": true,
@@ -21902,6 +21932,27 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/win-export-certificate-and-key": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/win-export-certificate-and-key/-/win-export-certificate-and-key-1.1.1.tgz",
+      "integrity": "sha512-wvF1DKlbt/PLOSdnKzIqv0Ipj+87n2VYOJFbkqBoN7l3l244reT7Lf6+Dnu86bYVWoVpq3ZZG417OLNHFnkP6A==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^4.3.0",
+        "node-forge": "^1.2.1"
+      }
+    },
+    "node_modules/win-export-certificate-and-key/node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "optional": true
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
@@ -31655,6 +31706,24 @@
         }
       }
     },
+    "macos-export-certificate-and-key": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/macos-export-certificate-and-key/-/macos-export-certificate-and-key-1.1.1.tgz",
+      "integrity": "sha512-J2g0dJRLG3DghmdCkbJnif/zPmSylj6ql//xBYff5allzNlHPnWxRoyho9XznBYLbPJw4jZlKjMO69jtV8VC7Q==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^4.3.0"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+          "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+          "optional": true
+        }
+      }
+    },
     "magic-string": {
       "version": "0.25.7",
       "dev": true,
@@ -35187,6 +35256,15 @@
       "version": "4.0.0",
       "dev": true
     },
+    "system-ca": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/system-ca/-/system-ca-1.0.2.tgz",
+      "integrity": "sha512-/6CCJOKB5Fpi0x7/DCbV7uiFPgwGCeJsAaSondXS2DjLBv7ER2worVGvQWJqPM0kgOKO6auaCcSWpJKnrDmXjw==",
+      "requires": {
+        "macos-export-certificate-and-key": "^1.1.1",
+        "win-export-certificate-and-key": "^1.1.1"
+      }
+    },
     "tapable": {
       "version": "2.2.1",
       "dev": true
@@ -36053,6 +36131,25 @@
     "wildcard": {
       "version": "2.0.0",
       "dev": true
+    },
+    "win-export-certificate-and-key": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/win-export-certificate-and-key/-/win-export-certificate-and-key-1.1.1.tgz",
+      "integrity": "sha512-wvF1DKlbt/PLOSdnKzIqv0Ipj+87n2VYOJFbkqBoN7l3l244reT7Lf6+Dnu86bYVWoVpq3ZZG417OLNHFnkP6A==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^4.3.0",
+        "node-forge": "^1.2.1"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+          "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+          "optional": true
+        }
+      }
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/packages/desktop-app/package.json
+++ b/packages/desktop-app/package.json
@@ -211,6 +211,7 @@
     "standard-version": "^9.3.0",
     "stream-browserify": "3.0.0",
     "sudo-prompt": "~9.2.1",
+    "system-ca": "^1.0.2",
     "tar": "^6.1.11",
     "tslib": "^2.3.1",
     "update-electron-app": "~2.0.1",

--- a/packages/desktop-app/src/app/components/integration-bar/integration-bar.component.html
+++ b/packages/desktop-app/src/app/components/integration-bar/integration-bar.component.html
@@ -64,6 +64,15 @@
               </div>
             </div>
           </div>
+
+          <div class="form-group">
+            <div class="form-field">
+              <div class="form-group">
+                <label><i class="fa fa-info-circle" matTooltip="By default Node's built-in certificate store is used. If you need to trust custom certificate, add certificate's CA into your OS as trusted and enable this setting. This feature is in beta."></i>&nbsp;Trust system CA</label>
+                <mat-checkbox (change)="trustSystemCAChanged($event)" [checked]="selectedConfiguration.trustSystemCA"></mat-checkbox>(Beta)
+              </div>
+            </div>
+          </div>
         </ng-container>
         <ng-container *ngIf="selectedIntegration === eIntegrationType.azure">
           <div class="form-group">

--- a/packages/desktop-app/src/app/components/integration-bar/integration-bar.component.ts
+++ b/packages/desktop-app/src/app/components/integration-bar/integration-bar.component.ts
@@ -65,6 +65,8 @@ export class IntegrationBarComponent implements OnInit, OnDestroy {
   ];
   selectedIntegration: string;
 
+  trustSystemCA: boolean;
+
   form = new FormGroup({
     alias: new FormControl("", [Validators.required]),
     portalUrl: new FormControl("", [Validators.required, Validators.pattern("https?://.+")]),
@@ -287,6 +289,7 @@ export class IntegrationBarComponent implements OnInit, OnDestroy {
       region: this.regions[0].region,
       portalUrl: "",
       browserOpening: constants.inApp,
+      trustSystemCA: false,
       accessTokenExpiration: undefined,
       tenantId: "",
     };
@@ -310,6 +313,7 @@ export class IntegrationBarComponent implements OnInit, OnDestroy {
     this.chooseIntegration = false;
     this.modifying = modifying;
     this.selectedConfiguration = integration;
+    console.log(this.selectedConfiguration.trustSystemCA);
     if (modifying === 1) {
       this.selectedConfiguration = {
         id: "new integration",
@@ -317,6 +321,7 @@ export class IntegrationBarComponent implements OnInit, OnDestroy {
         region: this.regions[0].region,
         portalUrl: "",
         browserOpening: constants.inApp,
+        trustSystemCA: false,
         accessTokenExpiration: undefined,
         tenantId: "",
       };
@@ -344,13 +349,14 @@ export class IntegrationBarComponent implements OnInit, OnDestroy {
       const portalUrl = this.form.get("portalUrl").value?.trim();
       const region = this.form.get("awsRegion").value;
       const browserOpening = this.form.get("defaultBrowserOpening").value;
+      const trustSystemCA = this.trustSystemCA;
       const tenantId = this.form.get("tenantId").value;
 
       let integrationParams: IntegrationParams;
       if (this.modifying > 0) {
         integrationParams =
           this.selectedIntegration === IntegrationType.awsSso
-            ? ({ alias, browserOpening, portalUrl, region } as IntegrationParams)
+            ? ({ alias, browserOpening, portalUrl, region, trustSystemCA } as IntegrationParams)
             : ({ alias, tenantId } as IntegrationParams);
       }
       if (this.modifying === 1) {
@@ -407,5 +413,9 @@ export class IntegrationBarComponent implements OnInit, OnDestroy {
 
   get defaultLocation(): string {
     return this.appProviderService.repository.getDefaultLocation();
+  }
+
+  trustSystemCAChanged(event: any): void {
+    this.trustSystemCA = event.checked;
   }
 }

--- a/packages/desktop-app/src/app/services/app-native.service.ts
+++ b/packages/desktop-app/src/app/services/app-native.service.ts
@@ -29,6 +29,7 @@ export class AppNativeService implements INativeService {
   machineId: any;
   ipcRenderer: any;
   keytar: typeof Keytar;
+  systemCertsAsync: any;
   followRedirects: any;
   httpProxyAgent: any;
   httpsProxyAgent: any;
@@ -62,6 +63,7 @@ export class AppNativeService implements INativeService {
       this.shell = window.require("electron").shell;
       this.machineId = window.require("node-machine-id").machineIdSync();
       this.keytar = window.require("keytar");
+      this.systemCertsAsync = window.require("system-ca").systemCertsAsync;
       this.followRedirects = window.require("follow-redirects");
       this.httpProxyAgent = window.require("http-proxy-agent");
       this.httpsProxyAgent = window.require("https-proxy-agent");


### PR DESCRIPTION
**Changelog**

Added option in AWS SSO integration for trusting system CA's. #320

**Bugfixes**

**Enhancements**

Users can opt-in to use system's CA certificate store instead of Node's built-in for trusting custom CA's when using AWS SSO integration.

**Notes**

Screenshot of new opt-in setting in "Add new integration" and Edit screens:
![image](https://user-images.githubusercontent.com/77069311/221382426-6c3425d4-ca28-4162-a340-b08e5338203a.png)


Built with:
```shell
nvm use
npm install
cd packages/core
npm install
npm run build
cd ../desktop-app
npm install ../core
npm run build-and-run-dev
```

Test environment:
Create small AWS EC2 t3.nano Ubuntu in public subnet, use/create key pair for being able to login with ssh
Allow 51820/UDP and 22/TCP in from your public ip
Login to EC2 with SSH: `ssh -i ~/.ssh/your-key.pem ubuntu@<ec2 public ip>`
Install mitmproxy:
```shell
get https://snapshots.mitmproxy.org/9.0.1/mitmproxy-9.0.1-linux.tar.gz
tar xzf mitmproxy-9.0.1-linux.tar.gz
```
Start mitmproxy in transparent wireguard mode: `./mitmweb --mode wireguard`

Install Wireguard into your machine
Copy wireguard configuration from EC2 machine's mitmproxy output. Eg:
```
[Interface]
PrivateKey = 4G..U=
Address = 10.0.0.1/32
DNS = 10.0.0.53

[Peer]
PublicKey = Pq..4=
AllowedIPs = 0.0.0.0/0
Endpoint = 10.0.15.79:51820
```
Replace DNS with eg. 1.1.1.1 and Endpoint's IP with EC2 public IP.
Activate Wireguard connection and test AWS SSO login with Leapp. It should fail with cert error.
Open magical http://mitm.it address with your browser and add mitmproxy's CA as trusted with provided instructions.
Opt-in "Trust system CA" and test AWS SSO login again. It should work.

CLI doesn't work at least with mitmproxy+wireguard combo and fails with connection refused error. It's yet to be tested if the issue exists also with other use cases.

Tests aren't written yet.