### PR TITLE
fix: do not prepend hardcoded path to command on darwin

### DIFF
--- a/packages/core/src/services/execute-service.ts
+++ b/packages/core/src/services/execute-service.ts
@@ -28,7 +28,6 @@ export class ExecuteService {
     }
     // NOTE: Electron works in sandbox mode when built.
     // Unfortunately this comes with some problems with executing OS commands.
-    // This code just uses absolute path for the commands Leapp uses to interact with both AWS and AZ command line tools.
     // If this part is modified for some reason,
     // PLEASE TEST BUILD APPLICATION BEFORE RELEASING
     if (this.nativeService.process.platform === "darwin") {
@@ -36,8 +35,6 @@ export class ExecuteService {
         command = "/usr/bin/" + command;
       } else if (command.indexOf("cd") !== -1) {
         command = "" + command;
-      } else {
-        command = "/usr/local/bin/" + command;
       }
     }
     // ========================================================

--- a/packages/core/src/services/execute-service.ts
+++ b/packages/core/src/services/execute-service.ts
@@ -33,8 +33,6 @@ export class ExecuteService {
     if (this.nativeService.process.platform === "darwin") {
       if (command.indexOf("osascript") !== -1) {
         command = "/usr/bin/" + command;
-      } else if (command.indexOf("cd") !== -1) {
-        command = "" + command;
       }
     }
     // ========================================================


### PR DESCRIPTION
**Changelog**

Removed the seemingly unneeded usage of a hardcoded absolute path for the AWS and AZ CLIs on MacOS.

This allows users to install these binaries to arbitrary locations and not have to symlink them to `/usr/local/bin`, as long as they are on the $PATH.

**Bugfixes**

Previously, users had to symlink the AWS and/or AZ binaries to `/usr/local/bin`, because the path was hardcoded. This is not possible in all situations, such as when installing the dependencies with the Nix package manager, which does not keep the binaries in the typical locations.


**Notes**

I have successfully built and tested this change using `npm run build-and-run-dev` - it works fine on MacOS 13.3.1. But the note in the comment does sound very intentional and scary, so additional testing may be necessary.

If the absolute path is indeed required, we can use `which` to find it out and substitue it in, just like in the old logic before this one was introduced:

[https://github.com/Noovolari/leapp/commit/eddc14555ba237fc647b06786d0ce58b0cd25c63#diff-e8f8f8acd268abe309247f729f[…]10f658433c252dea6fb15986cf3eb9f](https://github.com/Noovolari/leapp/commit/eddc14555ba237fc647b06786d0ce58b0cd25c63#diff-e8f8f8acd268abe309247f729f0d7eeb510f658433c252dea6fb15986cf3eb9f)

