### PR TITLE
docs: correct several minor issues and grammatical or spelling mistakes

### DIFF
--- a/docs/built-in-features/aws-ec2-connect.md
+++ b/docs/built-in-features/aws-ec2-connect.md
@@ -6,7 +6,7 @@ structured_data_how_to_title: "Configure AWS EC2 Connect"
 structured_data_how_to_tip1: "Right-click on a suitable AWS session to open the contextual menu. Click on View SSM sessions."
 structured_data_how_to_tip2: "Select the AWS region in which your instance is located. Wait for Leapp to load your instances."
 structured_data_how_to_tip3: "Select the instance and click connect. Wait for the terminal to open."
-structured_data_how_to_tip4: "Focus the terminal window and write ```/bin/bash```; press  ++return++  and you'll be inside the terminal of your Instance."
+structured_data_how_to_tip4: "Focus the terminal window and write ```/bin/bash```; press  ++return++  and you'll be inside the terminal of your instance."
 social_title: "Configure AWS EC2 Connect"
 social_description: "How to configure AWS EC2 Connect. You can directly connect to an AWS EC2 instance from Leapp through AWS System Manager (AWS SSM)."
 social_relative_image_path: "configure-ec2-connect.png"
@@ -36,13 +36,13 @@ You can directly connect to an AWS EC2 instance from Leapp through AWS System Ma
 
 To correctly connect follow these steps:
 
-1. Right-click on a suitable AWS session to open the contextual menu
-2. Click on View SSM sessions
-3. Select the AWS region in which your instance is located
-4. Wait for Leapp to load your instances
-5. Select the instance and click connect
-6. Wait for the terminal to open
-7. Focus the terminal window and write ```/bin/bash```; press  ++return++  and you'll be inside the terminal of your Instance
+1. Right-click on a suitable AWS session to open the contextual menu.
+2. Click on View SSM sessions.
+3. Select the AWS region in which your instance is located.
+4. Wait for Leapp to load your instances.
+5. Select the instance and click connect.
+6. Wait for the terminal to open.
+7. Focus the terminal window and write ```/bin/bash```; press  ++return++  and you'll be inside the terminal of your instance.
 
 ## Video tutorial
 

--- a/docs/built-in-features/general-options.md
+++ b/docs/built-in-features/general-options.md
@@ -1,4 +1,4 @@
-Once you opened the Leapp option menu - which can be accessed by clicking the top right gear icon - you can edit the following settings in the General tab
+Once you've opened the Leapp option menu - which can be accessed by clicking the top right gear icon - you can edit the following settings in the General tab
 
 ![](../../images/screens/newuxui/leapp-options.png?style=center-img)
 

--- a/docs/built-in-features/multi-console.md
+++ b/docs/built-in-features/multi-console.md
@@ -90,7 +90,7 @@ The extension can only be installed manually. To do so, follow these instruction
 
 ### How to use it
 
-Once you installed the extension on your browser, you need to enable the Multi-Console Extension on the Leapp Desktop App in order to use it.
+Once you've installed the extension on your browser, you need to enable the Multi-Console Extension on the Leapp Desktop App in order to use it.
 
 Click on the top-right cog icon to access the settings, click on the **Multi-Console** tab and then click **Enable Multi-Console Extension**.
 

--- a/docs/cli/scopes/help.md
+++ b/docs/cli/scopes/help.md
@@ -23,4 +23,4 @@ DESCRIPTION
   Display help for leapp.
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v5.2.6/src/commands/help.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/5.2.6/src/commands/help.ts)_

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,4 +1,4 @@
-Now it's time to add your very first configuration, follow the link to your preferred supported method and start enjoying Leapp. 
+Now it's time to add your very first configuration. Follow the link to your preferred supported method and start enjoying Leapp. 
 
 ## Sessions
 ### AWS

--- a/docs/configuring-integration/configure-aws-single-sign-on-integration.md
+++ b/docs/configuring-integration/configure-aws-single-sign-on-integration.md
@@ -3,10 +3,10 @@ title: "Configure an AWS Identity Center (ex AWS Single Sign-On) integration"
 description: "AWS Single Sign-On (AWS SSO) is a cloud service that allows you to grant your users access to AWS resources across multiple AWS accounts."
 pageType: "integration"
 structured_data_how_to_title: "Configure an AWS Identity Center (ex AWS Single Sign-On) integration"
-structured_data_how_to_tip1: "Click on the _Add integration_ button in the sidebar"
-structured_data_how_to_tip2: "Select AWS Identity Center (ex AWS Single Sign-On) as _Integration type_"
-structured_data_how_to_tip3: "Provide the required information (described in the next section)"
-structured_data_how_to_tip4: "Click on the _Add integration_ button"
+structured_data_how_to_tip1: "Click on the _Add Integration_ button in the sidebar."
+structured_data_how_to_tip2: "Select _AWS Single Sign-On_ as the Integration type."
+structured_data_how_to_tip3: "Provide the required information (described in the next section)."
+structured_data_how_to_tip4: "Click on the _Add integration_ button."
 social_title: "Configure an AWS Identity Center (ex AWS Single Sign-On) integration"
 social_description: "AWS Identity Center (ex AWS Single Sign-On) is a cloud service that allows you to grant your users access to AWS resources across multiple AWS accounts."
 social_relative_image_path: "aws-single-sign-on-integration.png"
@@ -28,10 +28,10 @@ After logging in the first time, Leapp will map all your roles and users into Se
 
 ## How to configure an AWS Identity Center (ex AWS Single Sign-On) integration in Leapp
 
-1. "Click on the _Add integration_ button in the sidebar"
-2. "Select AWS Single Sign-On as _Integration type_"
-3. "Provide the required information (described in the next section)"
-4. "Click on the _Add integration_ button"
+1. Click on the _Add Integration_ button in the sidebar.
+2. Select _AWS Single Sign-On_ as the Integration type.
+3. Provide the required information (described in the next section).
+4. Click on the _Add integration_ button.
 
 ## Required information
 
@@ -39,7 +39,7 @@ After logging in the first time, Leapp will map all your roles and users into Se
 | -------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `INTEGRATION TYPE` | Set as *AWS Single Sign-on*                                                                                                                                    |
 | `AWS SSO URL`      | **The portal URL to begin the authentication flow.** It usually follows this pattern: `d-xxxxxxxxxx.awsapps.com/start`.                                        |
-| `REGION`           | **The region on which AWS SSO is administered and configured.** This is NOT where your generated credentials will be valid, it's only used for the login part. |
+| `REGION`           | **The region on which AWS SSO is administered and configured.** This is NOT where your generated credentials will be valid; it's only used for the login part. |
 
 ![](../../images/screens/newuxui/aws-sso.png?style=center-img 'Add AWS SSO Screen')
 

--- a/docs/configuring-integration/configure-azure-integration.md
+++ b/docs/configuring-integration/configure-azure-integration.md
@@ -3,10 +3,10 @@ title: "Configure an Azure integration"
 description: "Our Leapp integration refers to Azure Tenant which is a dedicated and trusted instance of Azure AD."
 pageType: "integration"
 structured_data_how_to_title: "Configure an Azure integration"
-structured_data_how_to_tip1: "Click on the _Add integration_ button in the sidebar"
-structured_data_how_to_tip2: "Select Azure as _Integration type_"
-structured_data_how_to_tip3: "Provide the required information (described in the next section)"
-structured_data_how_to_tip4: "Click on the _Add integration_ button"
+structured_data_how_to_tip1: "Click on the _Add Integration_ button in the sidebar."
+structured_data_how_to_tip2: "Select _Azure_ as the Integration type."
+structured_data_how_to_tip3: "Provide the required information (described in the next section)."
+structured_data_how_to_tip4: "Click on the _Add integration_ button."
 social_title: "Configure an Azure integration"
 social_description: "Our Leapp integration refers to Azure Tenant which is a dedicated and trusted instance of Azure AD."
 social_relative_image_path: "azure.png"
@@ -28,19 +28,19 @@ Please refer to [How to find your Azure Active Directory tenant ID](https://docs
 
 !!! Warning
 
-    For azure-cli users with version < 2.30.0: Leapp no more support this version of the CLI. Please update to a newer version.
+    For azure-cli users with version < 2.30.0: Leapp no longer supports this version of the CLI. Please update to a newer version.
 
-To create a new Azure Integration go to the left sidebar of Leapp Desktop and click on the "+" icon. 
+To create a new Azure Integration, go to the left sidebar of Leapp Desktop and click on the :fontawesome-solid-circle-plus: icon. 
 A new modal will be presented with the following option to compile. After submitting the new Integration 
 and have logged into your *Azure Portal*, 
 *Subscriptions* will be automatically retrieved and mapped into Leapp Azure Sessions.
 
 ## How to configure an Azure integration in Leapp
 
-1. "Click on the _Add integration_ button in the sidebar"
-2. "Select Azure as _Integration type_"
-3. "Provide the required information (described in the next section)"
-4. "Click on the _Add integration_ button"
+1. Click on the _Add Integration_ button in the sidebar.
+2. Select _Azure_ as the Integration type.
+3. Provide the required information (described in the next section).
+4. Click on the _Add integration_ button.
 
 ## Required information
 

--- a/docs/configuring-session/configure-aws-iam-role-chained.md
+++ b/docs/configuring-session/configure-aws-iam-role-chained.md
@@ -3,11 +3,11 @@ title: "Configure AWS IAM Role Chained"
 description: "How to configure an AWS IAM Role Chained session. An AWS IAM Role Chained session represents an AWS role chaining access. Role chaining is the process of assuming a role starting from another IAM role or user."
 page_type: "session"
 structured_data_how_to_title: "Configure AWS IAM Role Chained"
-structured_data_how_to_tip1: "From the top bar, click on the plus icon to ass a new session."
-structured_data_how_to_tip2: "Select Amazon AWS as the Cloud Provider."
-structured_data_how_to_tip3: "Select "AWS IAM Role Chained" as the access method."
+structured_data_how_to_tip1: "From the top bar, click on the plus icon to add a new session."
+structured_data_how_to_tip2: "Select _Amazon AWS_ as the Cloud Provider."
+structured_data_how_to_tip3: "Select _AWS IAM Role Chained_ as the access method."
 structured_data_how_to_tip4: "Provide the required information (described in the next section)."
-structured_data_how_to_tip5: "Click on the Create Session button."
+structured_data_how_to_tip5: "Click on the _Create Session_ button."
 social_title: "Configure AWS IAM Role Chained"
 social_description: "How to configure an AWS IAM Role Chained session. An AWS IAM Role Chained session represents an AWS role chaining access. Role chaining is the process of assuming a role starting from another IAM role or user."
 social_relative_image_path: "aws-iam-role-chained-session.png"
@@ -30,11 +30,11 @@ Role chaining occurs when you use a role to assume a second role through the AWS
 
 ## How to configure an AWS IAM Role Chained in Leapp
 
-1. From the top bar, click on the plus icon to ass a new session.
-2. Select "Amazon AWS" as the Cloud Provider.
-3. Select "AWS IAM Role Chained" as the access method.
+1. From the top bar, click on the plus icon to add a new session.
+2. Select _Amazon AWS_ as the Cloud Provider.
+3. Select _AWS IAM Role Chained_ as the access method.
 4. Provide the required information (described in the next section).
-5. Click on the "Create Session" button.
+5. Click on the _Create Session_ button.
 
 ## Required information
 

--- a/docs/configuring-session/configure-aws-iam-role-federated.md
+++ b/docs/configuring-session/configure-aws-iam-role-federated.md
@@ -3,11 +3,11 @@ title: "Configure AWS IAM Role Federated"
 description: "How to configure an AWS IAM Role Federated session. An AWS IAM Role Federated session represents an access type that relies on a federation between an AWS account and an external Identity Provider."
 page_type: "session"
 structured_data_how_to_title: "Configure AWS IAM Role Federated"
-structured_data_how_to_tip1: "From the top bar, click on the plus icon to ass a new session."
-structured_data_how_to_tip2: "Select Amazon AWS as the Cloud Provider."
-structured_data_how_to_tip3: "Select "AWS IAM Role Federated" as the access method."
+structured_data_how_to_tip1: "From the top bar, click on the plus icon to add a new session."
+structured_data_how_to_tip2: "Select _Amazon AWS_ as the Cloud Provider."
+structured_data_how_to_tip3: "Select _AWS IAM Role Federated_ as the access method."
 structured_data_how_to_tip4: "Provide the required information (described in the next section)."
-structured_data_how_to_tip5: "Click on the Create Session button."
+structured_data_how_to_tip5: "Click on the _Create Session_ button."
 social_title: "Configure AWS IAM Role Federated"
 social_description: "How to configure an AWS IAM Role Federated session. An AWS IAM Role Federated session represents an access type that relies on a federation between an AWS account and an external Identity Provider."
 social_relative_image_path: "aws-iam-role-federated-session.png"
@@ -47,11 +47,11 @@ We currently only support SAML 2.0 federation.
 
 ## How to configure an AWS IAM Role Federated in Leapp
 
-1. From the top bar, click on the plus icon to ass a new session.
-2. Select "Amazon AWS" as the Cloud Provider.
-3. Select "AWS IAM Role Federated" as the access method.
+1. From the top bar, click on the plus icon to add a new session.
+2. Select _Amazon AWS_ as the Cloud Provider.
+3. Select _AWS IAM Role Federated_ as the access method.
 4. Provide the required information (described in the next section).
-5. Click on the "Create Session" button.
+5. Click on the _Create Session_ button.
 
 ## Required information
 

--- a/docs/configuring-session/configure-aws-iam-user.md
+++ b/docs/configuring-session/configure-aws-iam-user.md
@@ -3,10 +3,10 @@ title: "Configure AWS IAM User"
 description: "How to configure AWS IAM User session. An AWS IAM user is an entity that you create in AWS to represent the person or application that interact with AWS."
 page_type: "session"
 structured_data_how_to_title: "Configure AWS IAM User"
-structured_data_how_to_tip1: "From the top bar, click on the plus icon to ass a new session."
-structured_data_how_to_tip2: "Select Amazon AWS as the Cloud Provider."
+structured_data_how_to_tip1: "From the top bar, click on the plus icon to add a new session."
+structured_data_how_to_tip2: "Select _Amazon AWS_ as the Cloud Provider."
 structured_data_how_to_tip3: "Provide the required information (described in the next section)."
-structured_data_how_to_tip4: "Click on the Create Session button."
+structured_data_how_to_tip4: "Click on the _Create Session_ button."
 social_title: "Configure AWS IAM User"
 social_description: "How to configure AWS IAM User session. An AWS Identity and Access Management (IAM) user is an entity that you create in AWS to represent the person or application that uses it to interact with AWS."
 social_relative_image_path: "aws-iam-user-session.png"
@@ -26,11 +26,11 @@ An IAM User in AWS consists of a name and a set of long-term credentials. Leapp 
 
 ## How to configure an AWS IAM User in Leapp
 
-1. From the top bar, click on the plus icon to ass a new session.
-2. Select "Amazon AWS" as the Cloud Provider.
-3. Select "AWS IAM User" as the access method. 
+1. From the top bar, click on the plus icon to add a new session.
+2. Select _Amazon AWS_ as the Cloud Provider.
+3. Select _AWS IAM User_ as the access method. 
 4. Provide the required information (described in the next section). 
-5. Click on the "Create Session" button.
+5. Click on the _Create Session_ button.
 
 ## Required information
 

--- a/docs/edit-session.md
+++ b/docs/edit-session.md
@@ -12,19 +12,19 @@ A new modal will appear, allowing the user to choose which parameters to change.
 Below are the configuration options for every type of session:
 
 ### Iam User
-- Session Alias: the session name can be changed as a session is identified by a hidden id
+- Session Alias: the session name can be changed, as a session is identified by a hidden id
 - Named Profile: you can change a named profile and the session, if active, will restart itself
 - AWS Region: you can change the region and the session will restart itself, if active
-- Mfa Device (optional): can be left empty or, if you ad a valid device name or AWS Arn, it will prompt a modal for MFA code
+- Mfa Device (optional): can be left empty or, if you add a valid device name or AWS ARN, it will prompt a modal for MFA code
 - Access Key ID: Replace your session Access Key ID in the system vault
 - Secret Access Key: Replace your session Secret Access Key in the system vault
 
 ### IAM Role Chained
-- Session Alias: the session name can be changed as a session is identified by a hidden id
+- Session Alias: the session name can be changed, as a session is identified by a hidden id
 - Named Profile: you can change a named profile and the session, if active, will restart itself
 - AWS Region: you can change the region and the session will restart itself, if active
 - Role ARN: The role that you'll assume when chaining from an assumer window
-- Role Session Name: (optional), it will be used to identify thje chianed session
+- Role Session Name: (optional), it will be used to identify the chained session
 - Assumer Session: select a session from the list, it will be the Principal assuming the role
 
 !!! Info
@@ -32,12 +32,12 @@ Below are the configuration options for every type of session:
     You can also generate a new IAM Role Chained session from any other AWS session by right-clicking on a session and chosing "Create Chained Session"
 
 ### IAM Role Federated
-- Session Alias: the session name can be changed as a session is identified by a hidden id
+- Session Alias: the session name can be changed, as a session is identified by a hidden id
 - Named Profile: you can change a named profile and the session, if active, will restart itself
 - AWS Region: you can change the region and the session will restart itself, if active
 - Role ARN: Role of the Principal in AWS
 - SAML 2.0 Url: Federated URL needed for authentication to AWS
-- Identity Provider: the identity provider ARN that you have setup on AWS
+- Identity Provider: the identity provider ARN that you have set up on AWS
 
 After modifying all the parameters, a user can test their validity with *test credential generation*:
 
@@ -54,4 +54,4 @@ using a combination of an informative name plus the session hidden id.
 
 This way we reduce potential blast radius of an attacker tampering your machine.
 
-When editing a session Leapp will hide your secrets and you are also **unable to copy/paste them from the App**.
+When editing a session, Leapp will hide your secrets and you are also **unable to copy/paste them from the App**.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ The name **Leapp** is based on the word *leap* and is pronounced */l:ip/*. We ch
 
 Leapp CLI (Command Line Interface) for Leapp is built on Node.js with [Oclif](https://oclif.io/){: target='_blank'} and the **leapp core library**. 
 
-You can follow the [installation guidelines](installation/install-leapp/){: target='_blank'} in order to make it works!
+You can follow the [installation guidelines](installation/install-leapp/){: target='_blank'} in order to make it work!
 
 It allows you to use Leapp application functionality in your terminal.
 

--- a/docs/installation/install-leapp.md
+++ b/docs/installation/install-leapp.md
@@ -2,7 +2,7 @@
 
 ### MacOS, Windows, and Linux
 
-You can install Leapp by downloading the pre-built binaries for your OS on the website release page
+You can install Leapp by downloading the pre-built binaries for your OS on the website release page:
 
 [Download Leapp ⇩](https://www.leapp.cloud/releases){ .md-button .md-button--primary }
 

--- a/docs/installation/update-leapp.md
+++ b/docs/installation/update-leapp.md
@@ -36,7 +36,7 @@ Leapp can also be updated via [Homebrew Cask](https://brew.sh/){: target='_blank
 
 ## CLI
 
-Depeding on which method you used to install the CLI ([npm](https://www.npmjs.com/package/@noovolari/leapp-cli){: target='_blank'} or Homebrew on macOS) you can update it with the following commands:
+Depending on which method you used to install the CLI ([npm](https://www.npmjs.com/package/@noovolari/leapp-cli){: target='_blank'} or Homebrew on macOS), you can update it with the following commands:
 
 === "npm"
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,7 +1,5 @@
 This section provides an overview of Leapp's integrations, useful to extend the functionality of Leapp to 3rd party services.
 
-Integrations help manage access and identities on your preferred service of choice and use Leapp on your daily activities by automatically mapping them into [Sessions](../sessions/).
-
 Integrations help manage access and identities on your service of choice while using Leapp during your daily activities. They are automatically mapped into [Sessions](../sessions/).
 
 ## Actions
@@ -10,10 +8,10 @@ Integrations have four main actions available: **Create**, **Delete**, **Sync**,
 
 | Action    | Description |
 | --------- | ----------- |
-| `CREATE`  | **Configure a new Integration with the data needed to start the authentication flow.** Required to Sync and map the service response into Sessions. |
-| `DELETE`  | **Remove an existing Integration.** Removes all the associated Sessions as well and wipes everything related to the Integration from the system (tokens, cache, etc.) |
-| `SYNC`    | **Start the authentication flow to log into the Integration Provider.** Leapp will automatically retrieve all the related data and map the response into Sessions. Any change in your service of choice requires a manual Sync to reflect the current status. |
-| `LOGOUT`  | **Disable the Integration.** Removes all the Sessions but keeps the Integration data. Running a Sync will restore all the Sessions tied to it. |
+| `CREATE`  | :fontawesome-solid-square-plus:    &nbsp;**Configure a new Integration with the data needed to start the authentication flow.** Required to Sync and map the service response into Sessions. |
+| `DELETE`  | :fontawesome-solid-square-minus:    &nbsp;**Remove an existing Integration.** Removes all the associated Sessions as well and wipes everything related to the Integration from the system (tokens, cache, etc.) |
+| `SYNC`    | :fontawesome-solid-rotate:    &nbsp;**Start the authentication flow to log into the Integration Provider.** Leapp will automatically retrieve all the related data and map the response into Sessions. Any change in your service of choice requires a manual Sync to reflect the current status. |
+| `LOGOUT`  | :fontawesome-solid-lock-open:    &nbsp;**Disable the Integration.** Removes all the Sessions but keeps the Integration data. Running a Sync will restore all the Sessions tied to it. |
 
 ## Supported Services
 

--- a/docs/plugins/plugins-development.md
+++ b/docs/plugins/plugins-development.md
@@ -21,7 +21,7 @@ Currently available methods:
 ###fetch
 - **`fetch`**`(url: string): any`
 
-  Retrieve the content of an URL. Returns a promise for the URL
+  Retrieve the content of a URL. Returns a promise for the URL
 
   | argument          | type |  description |
   | -------------------------- | --------- | --------|
@@ -121,7 +121,7 @@ const res = await this.pluginEnvironment.fetch(""); //Insert a custom URL
 const response = await res.json();
 ```
 
-###Example: open an URL in the browser
+###Example: open a URL in the browser
 
 ```typescript
 this.pluginEnvironment.openExternalUrl("https://leapp.cloud");

--- a/docs/plugins/plugins-introduction.md
+++ b/docs/plugins/plugins-introduction.md
@@ -56,7 +56,7 @@ From Leapp Desktop App, right click on a session to open the contextual menu, cl
 
     This contextual menu option is not available if you have no plugins that you can run on the selected session and/or your operating system.
 
-From Leapp CLI, you can use the command `leapp session run-plugin`. For more information on how to use this CLI command, see the [documentation](https://docs.leapp.cloud/latest/cli/scopes/session/#leapp-session-run-aws-credential-plugin)
+From Leapp CLI, you can use the command `leapp session run-plugin`. For more information on how to use this CLI command, see the [documentation](https://docs.leapp.cloud/latest/cli/scopes/session/#leapp-session-run-aws-credential-plugin).
 
 ##Plugin Menu
 
@@ -70,7 +70,7 @@ From there, you can see a list of currently installed plugins, check whether a p
 
 You can start creating a plugin [from the template](https://github.com/Noovolari/leapp-plugin-template).
 
-Leapp plugins are written in TypeScript. They must contain at least a class that extend sa base class provided by the Plugin SDK
+Leapp plugins are written in TypeScript. They must contain at least a class that extends a base class provided by the Plugin SDK.
 
 There's currently only one of these classes, `AwsCredentialsPlugin` , that can be used to create a plugin that generates temporary credentials.
 

--- a/docs/security/credential-process.md
+++ b/docs/security/credential-process.md
@@ -6,16 +6,16 @@
 It is **a way to generate AWS compatible credentials on the fly**, only when requested by tools that respect the AWS credential chain.
 
 Credential Process **is perfect if you have a way to generate or look up credentials that isn't directly supported by the AWS CLI or third-party tools**; 
-for example, you can configure the AWS CLI to use it by configuring the credential_process setting in the config file.
+for example, you can configure the AWS CLI to use it by configuring the _credential_process_ setting in the config file.
 
 The difference between Credential Process and Standard Credential file is that **credentials in the "credential file" are written in plain text** and so, 
-they are potentially unsecure, even if temporary. Credential process instead, generates **credentials that are consumed only when they are effectively needed**. 
+they are potentially unsecure, even if temporary. Credential Process instead, generates **credentials that are consumed only when they are effectively needed**. 
 
 > No credential is written in any file. They are *printed* on the stdout and consumed upon request.
 
 ### How Credential Process works?
 
-Credentials process ask an external process to generate an AWS compatible temporary credential set in this format:
+Credential Process asks an external process to generate an AWS compatible temporary credential set in this format:
 ```json
 {
   "Version": 1,
@@ -30,26 +30,26 @@ The **Expiration** field allows the generated credentials to be cached and reuse
 
 ### Advantages
 - Ensures that no credential set is written on your machine in neither the ~/.aws/credentials or ~/.aws/config files.
-- Ensures your **long-running tasks** to always have valid credentials during their lifecycle.
+- Ensures your **long-running tasks** always have valid credentials during their lifecycle.
 - Is **compatible with named-profiles**.
 - Is **a way to make third-party tool compatible with AWS SSO and SAML Federated IAM Principals** even if they don't support them natively.
 - As stated by [this article](https://ben11kehoe.medium.com/never-put-aws-temporary-credentials-in-env-vars-or-credentials-files-theres-a-better-way-25ec45b4d73e){: target='_blank'} by Ben Kehoe, Credential Process is a good way to avoid cluttering the credential file with temporary credentials.
 
 !!! Warning
 
-    Temporary credentials in the credentials file reduce **potential blast radius** in case of machine exploit but they require to be refreshed everytime they expire.
+    Temporary credentials in the credentials file reduce **potential blast radius** in case of machine exploit but they require to be refreshed every time they expire.
 
 ### How Leapp works with Credential Process
 
 !!! Info
 
-    **Requirements**: this credentials' generation method requires that both Leapp desktop app and CLI are installed.
+    **Requirements**: this credentials generation method requires that both Leapp desktop app and CLI are installed.
 
 1) Open your Leapp desktop app and go to the settings panel (<img src="../../images/gear.png" width="20" alt="option icon" />).
 
 2) In the *general section* change the *AWS Credential Generation* from "credential-file-method" to **"credential-process-method"**.
 
-3) An informative panel will show app telling that you need the CLI installed (see below), click on "I acknowledge it"
+3) An informative panel will show up telling that you need the CLI installed (see below), click on "I acknowledge it"
 
 ![warning modal](../../images/modalcredentialprocess.png)
 
@@ -62,7 +62,7 @@ region=REGION
 ```
 
 5) You can start more than one session, depending on how many named-profile you've created; 
-for every session started with a unique named-profile a new entry will be created in the config file.
+for every session started with a unique named-profile, a new entry will be created in the config file.
 
 !!! Info
 

--- a/docs/security/credentials-generation/aws.md
+++ b/docs/security/credentials-generation/aws.md
@@ -35,7 +35,7 @@ An IAM Chained Role is used to access another AWS account services through a mai
 
 [How to generate temporary credentials on AWS](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html)
 
-**If you do not pass DurationSeconds parameter (as in the case of Leapp), the temporary credentials expire in 1 hour.**
+**If you do not pass the DurationSeconds parameter (as in the case of Leapp), the temporary credentials expire in 1 hour.**
 
 ## IAM User
 

--- a/docs/security/credentials-generation/azure.md
+++ b/docs/security/credentials-generation/azure.md
@@ -1,6 +1,6 @@
 ## Azure credentials generation
 
-Azure generates a set of access and refresh tokens that are put inside **msal_token_cache.json** inside **.azure** directory. 
+Azure generates a set of access and refresh tokens that are put inside the **msal_token_cache.json** file inside the **.azure** directory. 
 Following is the procedure used to generate a set of credentials.
 
 !!! info
@@ -12,13 +12,13 @@ Azure Users profile info is saved in the **azureProfile.json** file inside the *
 
 ### Access strategy - login integration
 
-Before accessing Azure sessions you now have to [create](../../configuring-integration/configure-azure-integration.md){: target='_blank'} an Azure integration.
-After that, these are the steps required to login and then retrieve Azure sessions.
+Before accessing Azure sessions, you now have to [create](../../configuring-integration/configure-azure-integration.md){: target='_blank'} an Azure integration.
+After that, these are the steps required to log in and then retrieve Azure sessions.
 
-1. *msal_token_cache* and *azureProfile.json* files are cleaned for security reason.
+1. *msal_token_cache* and *azureProfile.json* files are cleaned for security reasons.
 2. We execute `az login --tenantId <TENANTID>`. We do this to obtain the updated user profile and the refresh token (associated to this integration).
 3. We extract all the Azure subscriptions associated with the integration and for each one we map a Leapp Azure session.
-4. We extract the *refresh token*, *account*, and *profile* information from *msal_token_cache and azureProfile.json* and persist them in the [System's vault](../system-vault.md){: target='_blank'}.
+4. We extract the *refresh token*, *account*, and *profile* information from *msal_token_cache* and *azureProfile.json* and persist them in the [System's vault](../system-vault.md){: target='_blank'}.
 5. We also remove the previous information from the original files, to increase security and avoid external tampering.
 
 ### Access strategy - start session
@@ -34,7 +34,7 @@ To start an Azure session we follow these steps.
 2. *azureProfile.json* is only filled with profile information from the current subscription.
 3. We write the *account information* and the *refresh token* back in the *msal_token_cache*
 4. We execute `az account get-access-token --subscriptionId <SUBSCRIPTIONID>`, to retrieve the **access token** and the **id token** of the subscription.
-5. The previous command also write *access* and *id token* back to the *msal_token_cache file*.
+5. The previous command also writes *access* and *id token* back to the *msal_token_cache* file.
 6. We update the *expiration time* of the session to the current datetime.
 7. We update the *refresh token* in the Vault with the new information.
 8. We remove the *refresh token* from the *msal_token_cache*.
@@ -42,7 +42,7 @@ To start an Azure session we follow these steps.
 
 !!! info
 
-    - The **refresh token** is a long term credential that potentially lasts for **90 days**. The **access token** is a short term credential and last for **70 minutes**. [Source](https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens){: target='_blank'}
+    - The **refresh token** is a long term credential that potentially lasts for **90 days**. The **access token** is a short term credential and lasts for **70 minutes**. [Source](https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens){: target='_blank'}
 
 ### Access strategy - rotate session
 

--- a/docs/security/intro.md
+++ b/docs/security/intro.md
@@ -1,4 +1,4 @@
-**Leapp is built with a security-first approach.** Every information that has to be persisted is encrypted and saved on your workstation.
+**Leapp is built with a security-first approach.** Every piece of information that has to be persisted is encrypted and saved on your workstation.
 
 We devised two main methods to store data, based on its sensitiveness.
 

--- a/docs/security/system-vault.md
+++ b/docs/security/system-vault.md
@@ -2,7 +2,7 @@ Information that can be used, or potentially exploited, to gain access to cloud 
 
 Leapp uses [Keytar](https://github.com/atom/node-keytar/){: target='_blank'} as an interface to the secure vault on macOS, Windows and Linux systems.
 
-Every key is stored in the vault under the name **Leapp**, in the description you will find the underlying name used by Leapp to retrieve the secret.
+Every key is stored in the vault under the name **Leapp**. In the description, you will find the underlying name used by Leapp to retrieve the secret.
 
 ## Supported System Vaults
 

--- a/docs/security/zero-knowledge.md
+++ b/docs/security/zero-knowledge.md
@@ -21,7 +21,7 @@ When users have complete control of the encryption key, they control access to t
 
 ## Criteria
 
-** During any phase of the registration and login process **the client does not provide any password-related info to the server**.
+- During any phase of the registration and login process **the client does not provide any password-related info to the server**.
 - The server **does not store any information that can be used to guess the password in a convenient way**. In other words, the system must not be prone to brute force or dictionary attacks.
 - **Any sensible data is encrypted client-side**, the server will work with encrypted blocks only.
 - All the **implementation is released as open-source**.

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -9,6 +9,6 @@ A **Session** contains all the relevant information to let the dev connect to a 
 | ----------- | ------------------------------------ |
 | `START`     | :fontawesome-solid-play:    &nbsp;Make the temporary credentials available to the provider chain  |
 | `STOP`      | :fontawesome-solid-stop:    &nbsp;Removes the temporary credentials from the provider chain |
-| `ROTATE`    | :fontawesome-solid-undo-alt:    &nbsp;Generate new temporary credentials, and substitute the previous ones in the provider chain |
+| `ROTATE`    | :fontawesome-solid-rotate-left:    &nbsp;Generate new temporary credentials, and substitute the previous ones in the provider chain |
 
 The process of setting up Leapp Sessions is managed either **manually**, for each access method, or through **integrations** with third-party tools. Leapp stores all the Sessions available to the users locally, inside a configuration file called **Workspace.**

--- a/docs/troubleshooting/faq.md
+++ b/docs/troubleshooting/faq.md
@@ -1,7 +1,7 @@
 ## I'm using the open-source app, do you store my data online?
 **NO.**
 
-The open-source software don't transfer, persist, or share anything with other services. All your data is secured and encrypted on your workstation.
+The open-source software doesn't transfer, persist, or share anything with other services. All your data is secured and encrypted on your workstation.
 
 **Nobody can access it, not even ourselves.**
 
@@ -42,7 +42,7 @@ ln -s /path/to/my/az /usr/local/bin/az
 
 ## How can I add support to a new SAML 2.0 Identity Provider?
 
-To add support tu a new SAML 2.0 Identity Provider, you have to perform the following steps:
+To add support to a new SAML 2.0 Identity Provider, you have to perform the following steps:
 
 * create a [Fork](https://github.com/Noovolari/leapp/fork) of the Noovolari/leapp GitHub repository;
 * create a Pull Request and set up your local environment following _[Install dependencies and build packages](https://github.com/Noovolari/leapp/blob/master/DEVELOPMENT.md#development-environment-setup)_ section of the DEVELOPMENT.md;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,7 +108,9 @@ extra:
       make our documentation better.
 
 markdown_extensions:
-  - pymdownx.emoji
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
   - admonition
   - pymdownx.details
   - pymdownx.highlight


### PR DESCRIPTION

**Changelog**

This PR includes a few small fixes in the documentation:

- makes formatting in certain sections more consistent with the rest of the docs
- standardizes metadata to be consistent with the markdown across sections
- corrects some spelling and grammatical issues
- removes duplicate sentence explaining integrations
- fixes broken link to the help plugin code
- fixes the rendering of fontawesome icons* and adds several more

**Notes**

*The fontawesome icons that aren't rendering (e.g., [here](https://docs.leapp.cloud/latest/sessions/)) were broken by removing the `pymdownx.emoji` configuration (see [this commit](https://github.com/Noovolari/leapp/commit/2ca7b30b3bb7d34fe737cb464731e91cb73ba56e#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2L112-L114)). If that was intentional for some other reason, I'm happy to remove it again and just stuff the icons into the markdown directly.
