### PR TITLE
chore: update workflow action versions and templates

### DIFF
--- a/.github/GLOSSARY.md
+++ b/.github/GLOSSARY.md
@@ -11,7 +11,7 @@ An entity managed and trusted by an Identity Provider, which the Identity can au
 # Cloud Service Provider
 
 Provides cloud services and allows the creation and management of resources inside isolated accounts. 
-The provided services can be consumed through well defined and documented web APIs, CLI, and SDK.
+The provided services can be consumed through well-defined and documented web APIs, CLI, and SDK.
 
 # Federation
 
@@ -19,12 +19,12 @@ The process to establish a trust relationship between the Identity Provider and 
 Enables Developers and DevOps to access the cloud assets in the Federated Account through Single Sign-On 
 authentication against the Identity Provider.
 
-## Example: Federation between G Suite and aws
+## Example: Federation between G Suite and AWS
 
 Developer/DevOps authenticates against the Identity Provider through a URL that represents a SAML Application 
 in the context of G Suite. Once authenticated, the client uses the SAML assertion, returned by the Identity 
-Provider in the authentication phase, to invoke aws' assume-role-with-saml API; this returns a set of valid 
-credentials associated with a role in the Federated aws account.
+Provider in the authentication phase, to invoke AWS' assume-role-with-saml API; this returns a set of valid 
+credentials associated with a role in the Federated AWS account.
 
 # Trusting
 
@@ -32,9 +32,9 @@ The process to establish a trust relationship between two roles in different acc
 This access method requires a role in a Federated Account and a role in a Iam Role Chained Account and leverage a single 
 federation definition to access other accounts.
 
-## Example: Trusting between aws Roles
+## Example: Trusting between AWS Roles
 
-Developer/DevOps use a set of valid credentials from the Federated Account and invoke aws assume-role API targeting 
+Developer/DevOps use a set of valid credentials from the Federated Account and invoke AWS assume-role API targeting 
 the IamRoleChained Role. It's required a trust relationship on the IamRoleChained Role to allow the assume-role API to be called 
 from the Federated Role. To further enhance the security, a policy that restricts the assume-role action to the IamRoleChained
 Role is associated to the Federated Role.
@@ -94,7 +94,7 @@ The policy that implements the trust relationship between two entities.
 # Application
 
 A logical group of parameters defined inside the Identity Provider. This set of parameters enables a correct 
-federation process between the Identity Provider and a Federated Account. As far as now, Leapp supports a single 
+federation process between the Identity Provider and a Federated Account. For now, Leapp supports a single 
 type of Application: G Suite SAML App.
 
 ### SAML App
@@ -107,23 +107,25 @@ It is an Amazon Web Services resource that provides an entry point to the Federa
 It contains information about the Identity Provider federated to the Federated Account.
 
 # Access Strategy
+
 A way to access a Cloud Account's assets through a set of credentials.
 
 # Federated Access
+
 It's a way to obtain access to cloud assets in an account federated with external Identity Provider.
 Leapp currently supports 2 types of federated access:
 
-- **aws Federated Access** - A strategy to allow a Principal on G Suite to access a Federated Account on aws. 
+- **AWS Federated Access** - A strategy to allow a Principal on G Suite to access a Federated Account on AWS. 
 - **Azure Federated Access** - A strategy to allow access to one or more Azure Subscriptions, that belong to an Azure Tenant, through means of an Azure Active Directory.
 
 # Iam User Access
 
-Direct access to an aws account via IAM User's credentials.
+Direct access to an AWS account via IAM User's credentials.
 
 # IamRoleChained Access
 
-A strategy to allow access to a IamRoleChained Account by passing through a Federated Account. 
-That's an indirect way to access an aws account by granting a Federated Role permission 
+A strategy to allow access to an IamRoleChained Account by passing through a Federated Account. 
+That's an indirect way to access an AWS account by granting a Federated Role permission 
 to assume a IamRoleChained Role in the IamRoleChained Account.
 
 # Session
@@ -133,7 +135,7 @@ The session is the time frame where the user can perform a set of operations wit
 # Azure Tenant
 
 A tenant is the organization that owns and manages a specific instance of Microsoft cloud services. 
-It’s most often used in a inexact manner to refer to the set of Azure AD and Office 365 services for 
+It’s most often used in an inexact manner to refer to the set of Azure AD and Office 365 services for 
 an organization, e.g. “we’ve configured our tenant in this way.” A given organization might have many tenants,
 and when this is the case, the name of core domain of the tenant is usually used to remove any ambiguity. 
 The name of the core domain comes in the form *.onmicrosoft.com, where the * varies. A tenant may have many 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 ## [Please follow one of the issue templates](https://github.com/noovolari/leapp/issues/new/choose)
 
-To keep the backlog clean and actionable, issues should be opened using [one the provided issue templates](https://github.com/arcticicestudio/nord-visual-studio-code/issues/new/choose) to help maintainers and the community to understand it, find related reports and to resolve tickets faster.
+To keep the backlog clean and actionable, issues should be opened using [one of the provided issue templates](https://github.com/arcticicestudio/nord-visual-studio-code/issues/new/choose) to help maintainers and the community to understand it, find related reports and to resolve tickets faster.
 
 ### Support
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 **Changelog**
 
-List of new feature and/or fixes here.
+List of new features and/or fixes here.
 
 **Bugfixes**
 

--- a/.github/workflows/cli-ci-cd.yml
+++ b/.github/workflows/cli-ci-cd.yml
@@ -34,7 +34,7 @@ jobs:
           cd packages/cli
           npm run prepack
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -66,10 +66,10 @@ jobs:
         id: validator
         run: |
           git fetch
-          TAG=$(git tag --points-at $GITHUB_SHA)
+          TAG=$(git tag --points-at "$GITHUB_SHA")
           MATCH=$(echo "$TAG" | grep "^cli-v[0-9]\+\.[0-9]\+\.[0-9]\+$" || true)
           if [[ $MATCH != "" ]]; then IS_VALID_TAG=1; else IS_VALID_TAG=0; fi;
-          echo "::set-output name=VALID_TAG::$IS_VALID_TAG"
+          echo "VALID_TAG=$IS_VALID_TAG" >> "$GITHUB_OUTPUT"
 
       - name: If valid tag set
         if: steps.validator.outputs.VALID_TAG == 1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,11 +39,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/core-ci-cd.yml
+++ b/.github/workflows/core-ci-cd.yml
@@ -36,7 +36,7 @@ jobs:
           cd packages/core
           npm run build
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -68,10 +68,10 @@ jobs:
         id: validator
         run: |
           git fetch
-          TAG=$(git tag --points-at $GITHUB_SHA)
+          TAG=$(git tag --points-at "$GITHUB_SHA")
           MATCH=$(echo "$TAG" | grep "^core-v[0-9]\+\.[0-9]\+\.[0-9]\+$" || true)
           if [[ $MATCH != "" ]]; then IS_VALID_TAG=1; else IS_VALID_TAG=0; fi;
-          echo "::set-output name=VALID_TAG::$IS_VALID_TAG"
+          echo "VALID_TAG=$IS_VALID_TAG" >> "$GITHUB_OUTPUT"
 
       - name: If valid tag set
         if: steps.validator.outputs.VALID_TAG == 1

--- a/.github/workflows/desktop-app-cd.yml
+++ b/.github/workflows/desktop-app-cd.yml
@@ -32,11 +32,11 @@ jobs:
         id: validator
         run: |
           git fetch
-          TAG=$(git tag --points-at $GITHUB_SHA)
+          TAG=$(git tag --points-at "$GITHUB_SHA")
           REGEX="^v[0-9]+\.[0-9]+.[0-9]+"
           if [[ $TAG =~ $REGEX ]]; then IS_VALID_TAG=1; else IS_VALID_TAG=0; fi;
-          echo "::set-output name=VALID_TAG::$IS_VALID_TAG"
-          echo "::set-output name=TAG_VERSION::$TAG"
+          echo "VALID_TAG=$IS_VALID_TAG" >> "$GITHUB_OUTPUT"
+          echo "TAG_VERSION=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: If valid tag set
         if: steps.validator.outputs.VALID_TAG == 1
@@ -80,7 +80,7 @@ jobs:
           powershell "Compress-Archive './release/Leapp Setup $TAG_VERSION.exe' './release/Leapp-$TAG_VERSION-win.zip'"
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -112,7 +112,7 @@ jobs:
           rm -Rf ./release/builder-effective-config.yaml
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -182,7 +182,7 @@ jobs:
           zip "./release/Leapp-$TAG_VERSION-mac.zip" "./release/Leapp-$TAG_VERSION.dmg"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -253,7 +253,7 @@ jobs:
           zip "./release/Leapp-$TAG_VERSION-mac-arm64.zip" "./release/Leapp-$TAG_VERSION-arm64.dmg"
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -274,7 +274,7 @@ jobs:
     steps:
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -296,7 +296,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -315,7 +315,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/desktop-app-nightly-cd.yml
+++ b/.github/workflows/desktop-app-nightly-cd.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -90,7 +90,7 @@ jobs:
           powershell "Compress-Archive './release/Leapp Setup $TAG_VERSION.exe' './release/Leapp-$TAG_VERSION-win.zip'"
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -125,7 +125,7 @@ jobs:
           rm -Rf ./release/builder-effective-config.yaml
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -196,7 +196,7 @@ jobs:
           zip "./release/Leapp-$TAG_VERSION-mac.zip" "./release/Leapp-$TAG_VERSION.dmg"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -268,7 +268,7 @@ jobs:
           zip "./release/Leapp-$TAG_VERSION-mac-arm64.zip" "./release/Leapp-$TAG_VERSION-arm64.dmg"
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -287,7 +287,7 @@ jobs:
     steps:
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,27 +13,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: setup-python-3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
 
       - name: install-dependencies
         run: |
-          pip install mkdocs-material
-          pip install mkdocs-video
-          pip install mkdocs-img2fig-plugin
-          pip install mkdocs-git-revision-date-plugin
-          pip install git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git
-          pip install mkdocs-minify-plugin
-          pip install mike
+          pip install mkdocs-material \
+                      mkdocs-video \
+                      mkdocs-img2fig-plugin \
+                      mkdocs-git-revision-date-plugin \
+                      git+https://${GH_TOKEN}@github.com/squidfunk/mkdocs-material-insiders.git \
+                      mkdocs-minify-plugin \
+                      mike
 
       - name: get-leapp-version
         run: |
-          echo "PACKAGE_VERSION=$(cat packages/desktop-app/package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g' | tr -d '[[:space:]]')" >> $GITHUB_ENV
-          echo "${{env.PACKAGE_VERSION}}"
+          PACKAGE_VERSION=$(cat packages/desktop-app/package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g' | tr -d '[[:space:]]')
+          echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> "$GITHUB_ENV"
+          echo "$PACKAGE_VERSION"
 
       - name: deploy
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
     name: Lint PR
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v3.4.0
+      - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:


### PR DESCRIPTION

This PR includes a few minor updates to the GitHub templates and workflows:

**Bugfixes**

- Upgrades deprecated set-output GitHub Actions syntax
  - The current set-output syntax being used is deprecated and will be disabled on 2023-05-31 due to security concerns. See [GitHub Actions: Deprecating save-state and set-output commands | GitHub Changelog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) for details.
- Corrects some spelling and grammatical errors in GitHub templates and glossary
- Addresses several shellcheck warnings for the action run scripts

**Enhancements**

- Upgrades `configure-aws-credentials` action from `v1` to `v2` (see [update](https://github.com/aws-actions/configure-aws-credentials/tree/0e613a0980cbf65ed5b322eb7a1e075d28913a83#recent-updates))
- Upgrades `checkout` action from `v2` to `v3`
- Upgrades `CodeQL` actions from `v1` to `v2` (see [deprecation notice](https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/))
- Upgrades `action-semantic-pull-request` action from `v3` to `v5`
- Upgrades `setup-python` action from `v2` to `v4`
- Combines pip installs for `docs` action into one command, per best practice (also saves ~5sec from my testing)

**Notes**

These will also help get rid of the various deprecation warnings in the action logs.

