### PR TITLE
Add support for JumpCloud identity provider

### DIFF
--- a/docs/configuring-session/configure-aws-iam-role-federated.md
+++ b/docs/configuring-session/configure-aws-iam-role-federated.md
@@ -41,6 +41,7 @@ We currently only support SAML 2.0 federation.
 | `AZURE AD`        | :white_check_mark:                  | :white_check_mark: |
 | `AUTH0`           | :white_check_mark:                  | :x:                |
 | `KEYCLOAK`        | :white_check_mark:                  | :x:                |
+| `JUMPCLOUD`       | :white_check_mark:                  | :x:                |
 
 !!! Info
     Is your SAML 2.0 Identity Provider not included in the above list? Please, refer to the [FAQ](/latest/troubleshooting/faq/#how-can-i-add-support-to-a-new-saml-20-identity-provider) to add a new one.

--- a/packages/core/src/services/aws-saml-assertion-extraction-service.ts
+++ b/packages/core/src/services/aws-saml-assertion-extraction-service.ts
@@ -16,6 +16,7 @@ const authenticationUrlRegexes = new Map([
       /^https:\/\/login\.microsoftonline\.com\/*.*\/oauth2\/authorize.*/,
       /^https:\/\/.+\.auth0\.com\/samlp\/.+/,
       /^https:\/\/.*\/auth\/realms\/.*\/protocol\/saml\/clients\/.*/,
+      /^https:\/\/sso\.jumpcloud\.com\/saml2\/aws/,
     ],
   ],
 ]);


### PR DESCRIPTION
**Changelog**

Add support for JumpCloud identity provider according to [Leapp docs](https://docs.leapp.cloud/latest/troubleshooting/faq/#how-can-i-add-support-to-a-new-saml-20-identity-provider).

