### PR TITLE
docs: Update docs and labels to use proper casing of LocalStack

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,4 +1,4 @@
-Now it's time to add your very first configuration. Follow the link to your preferred supported method and start enjoying Leapp. 
+Now it's time to add your very first configuration. Follow the link to your preferred supported method and start enjoying Leapp.
 
 ## Sessions
 ### AWS
@@ -11,7 +11,7 @@ Then follow the links below.
 - [Configure an AWS IAM User](configuring-session/configure-aws-iam-user.md)
 - [Configure an AWS IAM Role Federated](configuring-session/configure-aws-iam-role-federated.md)
 - [Configure an AWS IAM Role Chained](configuring-session/configure-aws-iam-role-chained.md)
-- [Configure Localstack](configuring-session/configure-localstack.md)
+- [Configure LocalStack](configuring-session/configure-localstack.md)
 
 ## Integrations
 

--- a/docs/configuring-session/configure-localstack.md
+++ b/docs/configuring-session/configure-localstack.md
@@ -1,38 +1,38 @@
 ---
-title: "Configure Localstack"
-description: "How to configure Localstack session"
+title: "Configure LocalStack"
+description: "How to configure LocalStack session"
 page_type: "session"
-structured_data_how_to_title: "Configure Localstack"
+structured_data_how_to_title: "Configure LocalStack"
 structured_data_how_to_tip1: "From the top bar, click on the plus icon to add a new session."
-structured_data_how_to_tip2: "Select _Localstack_ as the Cloud Provider."
+structured_data_how_to_tip2: "Select _LocalStack_ as the Cloud Provider."
 structured_data_how_to_tip3: "Provide the required information (described in the next section)."
 structured_data_how_to_tip4: "Click on the _Create Session_ button."
 ---
 
-## What is a Localstack session
+## What is a LocalStack session
 
-With Localstack you can emulate AWS cloud services with a fully functional cloud stack on your local machine.
+With LocalStack you can emulate AWS cloud services with a fully functional cloud stack on your local machine.
 Develop and test your cloud applications with the full cloud experience, but without the hassle of the remote cloud.
 
-You can use Leapp to create a Localstack session that can then be used to set your local credential file and access your Localstack resources.
+You can use Leapp to create a LocalStack session that can then be used to set your local credential file and access your LocalStack resources.
 
 !!! Info
 
-    You need to [install Localstack](https://docs.localstack.cloud/getting-started/){: target='_blank'} in order to use the AWS cloud emulation features
+    You need to [install LocalStack](https://docs.localstack.cloud/getting-started/){: target='_blank'} in order to use the AWS cloud emulation features
 
 
-## How to configure a Localstack session in Leapp
+## How to configure a LocalStack session in Leapp
 
 1. From the top bar, click on the plus icon to add a new session.
-2. Select _Localstack_ as the Cloud Provider. 
-3. Provide a name for the session. 
+2. Select _LocalStack_ as the Cloud Provider.
+3. Provide a name for the session.
 4. Click on the _Create Session_ button.
 
 !!! Warning
 
-    Localstack sessions work only with [AWS Credential Method](../security/credentials-generation/aws.md) configured with the `credential-file-method` option. 
+    LocalStack sessions work only with [AWS Credential Method](../security/credentials-generation/aws.md) configured with the `credential-file-method` option.
     The option is available in the _Options_ menu > _General_ > _Generics_ > _AWS Credential Method_.
 
 !!! Warning
 
-    In order to use the credential file to access Localstack from your AWS CLI, you must update the AWS CLI to the [latest version](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html){: target='_blank'}.
+    In order to use the credential file to access LocalStack from your AWS CLI, you must update the AWS CLI to the [latest version](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html){: target='_blank'}.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,7 +30,7 @@ nav:
           - 'Configure AWS IAM User': 'configuring-session/configure-aws-iam-user.md'
           - 'Configure AWS IAM Role Federated': 'configuring-session/configure-aws-iam-role-federated.md'
           - 'Configure AWS IAM Role Chained': 'configuring-session/configure-aws-iam-role-chained.md'
-          - 'Configure Localstack': 'configuring-session/configure-localstack.md'
+          - 'Configure LocalStack': 'configuring-session/configure-localstack.md'
       - 'Configuring an Integration':
           - 'Configure AWS Single Sign-On integration': 'configuring-integration/configure-aws-single-sign-on-integration.md'
           - 'Configure Azure integration': 'configuring-integration/configure-azure-integration.md'

--- a/packages/core/src/services/cloud-provider-service.ts
+++ b/packages/core/src/services/cloud-provider-service.ts
@@ -139,7 +139,7 @@ export class CloudProviderService {
         [
           new AccessMethod(
             SessionType.localstack,
-            "Localstack",
+            "LocalStack",
             [
               new AccessMethodField("sessionName", "Insert session alias", AccessMethodFieldType.input),
               new AccessMethodField("region", "Select Location", AccessMethodFieldType.list, awsRegionChoices),

--- a/packages/core/src/services/session/localstack/localstack-session-service.spec.ts
+++ b/packages/core/src/services/session/localstack/localstack-session-service.spec.ts
@@ -186,7 +186,7 @@ describe("LocalstackSessionService", () => {
   test("generateProcessCredentials", async () => {
     const service = new LocalstackSessionService(null, null, null, null);
     await expect(service.generateProcessCredentials(undefined)).rejects.toThrow(
-      new Error("Localstack only support Credential file method, please switch back to it in the option panel.")
+      new Error("LocalStack only support Credential file method, please switch back to it in the option panel.")
     );
   });
 

--- a/packages/desktop-app/src/app/components/dialogs/create-dialog/create-dialog.component.html
+++ b/packages/desktop-app/src/app/components/dialogs/create-dialog/create-dialog.component.html
@@ -12,7 +12,7 @@
       <button type="button" class="providers" (click)="setProvider(eSessionType.awsIamRoleFederated);"><img src="./assets/images/aws{{optionsService.colorTheme === eConstants.darkTheme || (optionsService.colorTheme === eConstants.systemDefaultTheme && appService.isDarkMode()) ? '-dark' : ''}}.png" width="36" alt=""> Amazon AWS</button>
       <button type="button" class="providers" (click)="setAzureProvider();"><img src="./assets/images/azure{{optionsService.colorTheme === eConstants.darkTheme || (optionsService.colorTheme === eConstants.systemDefaultTheme && appService.isDarkMode()) ? '-dark' : ''}}.png" width="36" alt=""> Microsoft Azure</button>
 
-      <button type="button" class="providers" (click)="setProvider(eSessionType.localstack);"><img src="./assets/images/localstack.png" width="36" alt=""> Localstack</button>
+      <button type="button" class="providers" (click)="setProvider(eSessionType.localstack);"><img src="./assets/images/localstack.png" width="36" alt=""> LocalStack</button>
       <button type="button" class="providers disabled" (click)="false; //setProvider(eSessionType.alibaba);"><img src="./assets/images/alibaba.png" width="36" alt=""> Alibaba Cloud</button>
     </div>
     <p>Do you want to add an Integration? <a class="btn-link" (click)="goToAwsSso()">View Integration settings</a></p>

--- a/packages/desktop-app/src/app/components/sessions/session-card/session-card.component.ts
+++ b/packages/desktop-app/src/app/components/sessions/session-card/session-card.component.ts
@@ -118,7 +118,7 @@ export class SessionCardComponent implements OnInit {
       case SessionType.azure:
         return "Azure";
       case SessionType.localstack:
-        return "Localstack";
+        return "LocalStack";
       case SessionType.awsIamUser:
         return "IAM User";
       case SessionType.awsSsoRole:


### PR DESCRIPTION
Hey folks 👋  - thanks so much for adding support for LocalStack, it looks awesome in the app, and works like a charm! 🚀 

I'd like to propose a few minor cosmetic changes in the docs and the labels in the app - using the CamelCase spelling `LocalStack` that we use for the product (instead of `Localstack`).

Keep up the great work! 🙌 

/cc @andreacavagna01 @ericvilla 