### PR TITLE
fix: change the authentication URL regexp for Auth0 provider

### DIFF
--- a/packages/core/src/services/aws-saml-assertion-extraction-service.ts
+++ b/packages/core/src/services/aws-saml-assertion-extraction-service.ts
@@ -14,7 +14,7 @@ const authenticationUrlRegexes = new Map([
       /^https:\/\/login\.okta\.com\/.*/,
       /^https:\/\/accounts\.google\.com\/ServiceLogin.*/,
       /^https:\/\/login\.microsoftonline\.com\/*.*\/oauth2\/authorize.*/,
-      /^https:\/\/.+\.auth0\.com\/samlp\/.+/,
+      /^https:\/\/.+\.auth0\.com\/u\/login\/.+/,
       /^https:\/\/.*[/auth]?\/realms\/.*\/protocol\/saml\/clients\/.*/,
       /^https:\/\/console\.jumpcloud\.com\/login.*/,
       /^https:\/\/accounts\.google\.com\/AccountChooser.*/,


### PR DESCRIPTION
**Changelog**

- authentication URL regexp for Auth0 provider

**Bugfixes**

At the moment, the regexp used to check if the URL is an authentication URL for Auth0 checks if `/samlp` is in the URL. The correct one instead checks if `/u/login` is present.
This misconfiguration causes the opening of the login modal window for every credential refresh process because the `needAuthentication` method always resolves with `true`.


