### PR TITLE
feat: make Web Console URL log out from current browser session

### DIFF
--- a/packages/core/src/services/web-console-service.spec.ts
+++ b/packages/core/src/services/web-console-service.spec.ts
@@ -61,19 +61,23 @@ describe("WebConsoleService", () => {
       },
     };
 
-    const signinToken = credentialsInfo.sessionToken.aws_session_token;
-    let federationUrl = "https://signin.aws.amazon.com/federation";
-    let consoleHomeURL = `https://${mockedSessionRegion}.console.aws.amazon.com/console/home?region=${mockedSessionRegion}`;
-    let truthUrl = `${federationUrl}?Action=login&Issuer=Leapp&Destination=${consoleHomeURL}&SigninToken=${signinToken}`;
+    let truthUrl =
+      "https://us-east-1.signin.aws.amazon.com/oauth?Action=logout&redirect_uri=" +
+      "https%3A%2F%2Fus-east-1.signin.aws.amazon.com%2Ffederation%3FAction%3Dlogin" +
+      "%26Issuer%3DLeapp%26Destination%3Dhttps%253A%252F%252Feu-west-1.console.aws.amazon.com%252F" +
+      "console%252Fhome%253Fregion%253Deu-west-1%26SigninToken%3Dmocked-aws_session_token";
 
     const webConsoleService: WebConsoleService = getService();
     const result1 = await webConsoleService.getWebConsoleUrl(credentialsInfo, mockedSessionRegion, mockedSessionDuration);
     expect(result1).toStrictEqual(truthUrl);
 
     mockedSessionRegion = "us-gov-";
-    federationUrl = "https://signin.amazonaws-us-gov.com/federation";
-    consoleHomeURL = `https://console.amazonaws-us-gov.com/console/home?region=${mockedSessionRegion}`;
-    truthUrl = `${federationUrl}?Action=login&Issuer=Leapp&Destination=${consoleHomeURL}&SigninToken=${signinToken}`;
+    truthUrl =
+      "https://us-east-1.signin.amazonaws-us-gov.com/oauth?Action=logout&redirect_uri=" +
+      "https%3A%2F%2Fus-east-1.signin.amazonaws-us-gov.com%2Ffederation%3FAction%3Dlogin" +
+      "%26Issuer%3DLeapp%26Destination%3Dhttps%253A%252F%252Fconsole.amazonaws-us-gov.com%252F" +
+      "console%252Fhome%253Fregion%253Dus-gov-%26SigninToken%3Dmocked-aws_session_token";
+
     const result2 = await webConsoleService.getWebConsoleUrl(credentialsInfo, mockedSessionRegion);
     expect(result2).toStrictEqual(truthUrl);
   });


### PR DESCRIPTION
**Changelog**

* Make Web Console URL log out from current browser session

**Enhancements**

This change to the Web Console URL makes AWS log out from any existing browser session, which avoids requiring a manual logout.

The implemented approach is based on [1] and its replies. It was found during testing that the sign-in links require the `us-east-1` domain prefix. Otherwise, the URL either redirects to the AWS Console landing page, or returns a 400 error.

Closes #309.

**Notes**

I tested this change with AWS SSO and many AWS accounts, in multiple regions for US and EU. I don't have access to any AWS GovCloud account, so it would be interesting if anyone can test this change and validate whether it works for GovCloud.

[1] https://serverfault.com/a/1097528