### PR TITLE
fix: add aws-cn saml endpoint

### DIFF
--- a/packages/core/src/services/aws-saml-assertion-extraction-service.spec.ts
+++ b/packages/core/src/services/aws-saml-assertion-extraction-service.spec.ts
@@ -46,6 +46,7 @@ describe("AwsSamlAssertionExtractionService", () => {
     expect(service.isSamlAssertionUrl(CloudProviderType.aws, "https://signin.aws.amazon.com/saml")).toBe(true);
     expect(service.isSamlAssertionUrl(CloudProviderType.aws, "https://signin.aws.amazon.com/saml?XX")).toBe(true);
     expect(service.isSamlAssertionUrl(CloudProviderType.aws, "http://signin.aws.amazon.com/saml")).toBe(false);
+    expect(service.isSamlAssertionUrl(CloudProviderType.aws, "https://signin.amazonaws.cn/saml")).toBe(true);
   });
 
   test("extractAwsSamlResponse", () => {

--- a/packages/core/src/services/aws-saml-assertion-extraction-service.ts
+++ b/packages/core/src/services/aws-saml-assertion-extraction-service.ts
@@ -23,7 +23,7 @@ const authenticationUrlRegexes = new Map([
 ]);
 
 const samlAssertionRegexes = new Map([
-  [CloudProviderType.aws, [/^https:\/\/signin\.aws\.amazon\.com\/saml/, /^https:\/\/signin\.amazonaws-us-gov\.com\/saml/]],
+  [CloudProviderType.aws, [/^https:\/\/signin\.aws\.amazon\.com\/saml/, /^https:\/\/signin\.amazonaws-us-gov\.com\/saml/, /^https:\/\/signin\.amazonaws\.cn\/saml/]],
 ]);
 
 export class AwsSamlAssertionExtractionService {


### PR DESCRIPTION
**Changelog**

in order to make federated role working with aws cn environment ,add aws-cn saml endpoint(https://signin.amazonaws.cn/saml) in `packages/core/src/services/aws-saml-assertion-extraction-service.ts` 

