### PR TITLE
fix(core): remove typo on generating web session signin token

### DIFF
--- a/packages/core/src/services/web-console-service.ts
+++ b/packages/core/src/services/web-console-service.ts
@@ -42,7 +42,7 @@ export class WebConsoleService {
       sessionToken: credentialsInfo.sessionToken.aws_session_token,
     };
 
-    const queryParametersSigninToken = `?Action=getSigninToken&sessionDuration=${sessionDuration}&Session=${encodeURIComponent(
+    const queryParametersSigninToken = `?Action=getSigninToken&SessionDuration=${sessionDuration}&Session=${encodeURIComponent(
       JSON.stringify(sessionStringJSON)
     )}`;
 


### PR DESCRIPTION
**Changelog**

Corrected case sensitivity issue in query parameters for session duration in sign-in token generation.

**Bugfixes**

Fixed a bug where the session duration parameter was ignored due to a case sensitivity error in the query string. This issue caused Amazon's default session duration of 1 hour to be used regardless of the intended duration.

**Enhancements**

Enhanced the reliability of session duration handling by fixing the typo in the parameter name from sessionDuration to SessionDuration.

**Notes**

This fix aligns the parameter casing with Amazon's API requirements, ensuring that session duration settings are correctly applied. This change is crucial for systems that depend on longer session durations for extended operations.

