### PR TITLE
feat: add support for GitHub OAuth authentication URLs

### DIFF
--- a/packages/core/src/services/aws-saml-assertion-extraction-service.spec.ts
+++ b/packages/core/src/services/aws-saml-assertion-extraction-service.spec.ts
@@ -38,6 +38,11 @@ describe("AwsSamlAssertionExtractionService", () => {
     expect(service.isAuthenticationUrl(CloudProviderType.aws, "https://XX/realms/XX/protocol/saml/clients/XX")).toBe(true);
 
     expect(service.isAuthenticationUrl(CloudProviderType.aws, "https://console.jumpcloud.com/login.mocked-suffix")).toBe(true);
+
+    /* Tests for GitHub OAuth Identity Providers */
+    expect(service.isAuthenticationUrl(CloudProviderType.aws, "https://github.XX/login/oauth/authorize")).toBe(true);
+    expect(service.isAuthenticationUrl(CloudProviderType.aws, "https://github.XX/login")).toBe(false);
+    expect(service.isAuthenticationUrl(CloudProviderType.aws, "https://github.XX")).toBe(false);
   });
 
   test("isSamlAssertionUrl", () => {

--- a/packages/core/src/services/aws-saml-assertion-extraction-service.ts
+++ b/packages/core/src/services/aws-saml-assertion-extraction-service.ts
@@ -18,6 +18,7 @@ const authenticationUrlRegexes = new Map([
       /^https:\/\/.*[/auth]?\/realms\/.*\/protocol\/saml\/clients\/.*/,
       /^https:\/\/console\.jumpcloud\.com\/login.*/,
       /^https:\/\/accounts\.google\.com\/AccountChooser.*/,
+      /^https:\/\/github\..+\/login\/oauth\/authorize.*/,
     ],
   ],
 ]);


### PR DESCRIPTION
This PR adds support for SAML authentication flows that use GitHub OAuth for authentication.

## The Problem

I was trying to use Leapp with a SAML provider that uses GitHub Enterprise for authentication. When I clicked "Start" on my session, Leapp would immediately show an error:

```
SAML authentication timeout exceeded
```

The browser window never opened, and the session failed after just 5 seconds.

## Why This Happened

Here's what was going on:

1. My SAML provider redirects to GitHub OAuth for authentication (like `https://github.example.com/login/oauth/authorize`)
2. Leapp monitors URL redirects during authentication and has a list of recognized authentication services (Okta, OneLogin, Google, etc.)
3. When Leapp sees an unrecognized URL, it assumes something went wrong and times out after 5 seconds
4. GitHub OAuth URLs weren't in the recognized list, so Leapp timed out before I could authenticate

## The Fix

I added GitHub OAuth URLs to the list of recognized authentication services:

```typescript
/^https:\/\/github\..+\/login\/oauth\/authorize.*/
```

This pattern works with any GitHub instance:
- Public GitHub (`github.com`)
- GitHub Enterprise (`github.enterprise.com`)
- Custom GitHub Enterprise domains

Now when Leapp encounters a GitHub OAuth redirect, it recognizes it as a valid authentication step and waits for you to complete the login instead of timing out.

## Testing

Before: Session failed with timeout error, browser never opened
After: Browser opens, I can log in with GitHub, and the SAML flow completes successfully

This should work for anyone using GitHub (public or Enterprise) as part of their AWS SAML authentication flow.