### PR TITLE
fix(desktop): guard ErrorService when logService is unavailable 

### DIFF
--- a/packages/desktop-app/src/app/services/middleware/error.service.ts
+++ b/packages/desktop-app/src/app/services/middleware/error.service.ts
@@ -13,12 +13,21 @@ export class ErrorService implements ErrorHandler {
     console.log("ERROREEE:", error);
 
     error = (error as any).rejection ? (error as any).rejection : error;
-    const logService = this.injector.get(AppProviderService).logService;
 
-    if (error instanceof LoggedException) {
-      logService.log(error);
-    } else {
-      logService.log(new LoggedEntry(error.message, this, LogLevel.error, true, error.stack));
+    try {
+      const logService = this.injector.get(AppProviderService)?.logService;
+      if (!logService || typeof logService.log !== "function") {
+        console.error("[Leapp] ErrorService: logService unavailable; original error:", error);
+        return;
+      }
+
+      if (error instanceof LoggedException) {
+        logService.log(error);
+      } else {
+        logService.log(new LoggedEntry(error.message, this, LogLevel.error, true, error.stack));
+      }
+    } catch (secondaryError) {
+      console.error("[Leapp] ErrorService.handleError failed; original error:", error, secondaryError);
     }
   }
 }


### PR DESCRIPTION
Prevent white screen / bootstrap failure when logService.log is not ready (e.g. TypeError: Cannot read properties of undefined (reading 'log')).

Fallback to console.error; wrap logging in try/catch.

Related: https://github.com/Noovolari/leapp/issues/524

**Changelog**

List of new feature and/or fixes here.

**Bugfixes**

Describe the fixes and specifying the issue if related.

**Enhancements**

Describe the enhancements specifying the issue if related.

**Notes**

Write eventual notes or reminders specifying if you have any sort of reference

